### PR TITLE
Implement iterative insert 

### DIFF
--- a/examples/tree_to_dot.rs
+++ b/examples/tree_to_dot.rs
@@ -1,6 +1,8 @@
 use argh::FromArgs;
 use blart::{
-    deallocate_tree, insert_unchecked, visitor::DotPrinter, LeafNode, NodePtr, OpaqueNodePtr,
+    deallocate_tree, insert_unchecked,
+    visitor::{DotPrinter, DotPrinterSettings},
+    LeafNode, NodePtr, OpaqueNodePtr,
 };
 use std::{
     error::Error,
@@ -85,7 +87,16 @@ fn make_tree(iter: impl Iterator<Item = Box<[u8]>>) -> Option<OpaqueNodePtr<usiz
 }
 
 fn write_tree(output: &mut dyn Write, tree: &OpaqueNodePtr<usize>) -> Result<(), Box<dyn Error>> {
-    DotPrinter::print_tree(output, &tree)?;
+    // SAFETY: There are no concurrent mutation to the tree node or its children
+    unsafe {
+        DotPrinter::print_tree(
+            output,
+            &tree,
+            DotPrinterSettings {
+                display_node_address: false,
+            },
+        )?
+    };
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,12 @@
 //!
 //! # References
 //!
-//!  - Leis, V., Kemper, A., & Neumann, T. (2013, April). The adaptive radix tree: ARTful indexing for main-memory databases. In 2013 IEEE 29th International Conference on Data Engineering (ICDE) (pp. 38-49). IEEE. [Link to PDF](https://www-db.in.tum.de/~leis/papers/ART.pdf)
+//!  - Leis, V., Kemper, A., & Neumann, T. (2013, April). The adaptive radix
+//!    tree: ARTful indexing for main-memory databases. In 2013 IEEE 29th
+//!    International Conference on Data Engineering (ICDE) (pp. 38-49). IEEE.
+//!    [Link to PDF][ART paper]
+//!
+//! [ART paper]: https://www-db.in.tum.de/~leis/papers/ART.pdf
 
 mod nodes;
 pub mod tagged_pointer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(
     maybe_uninit_uninit_array,
     maybe_uninit_slice,
-    never_type,
     nonnull_slice_from_raw_parts,
     slice_ptr_get,
     strict_provenance

--- a/src/nodes/operations.rs
+++ b/src/nodes/operations.rs
@@ -459,7 +459,7 @@ pub unsafe fn deallocate_tree<V>(root: OpaqueNodePtr<V>) {
             // lifetime of the `inner_node` variable. By the safety requirements of the
             // `deallocate_tree` function, no other mutation of this node can happen while
             // this iterator is live.
-            let iter = unsafe { inner_node.into_iter() };
+            let iter = unsafe { inner_node.iter() };
             stack.extend(iter.map(|(_, child)| child));
         }
         // SAFETY: The single call per node requirement is enforced by the safety
@@ -504,7 +504,7 @@ pub unsafe fn minimum_unchecked<V>(root: OpaqueNodePtr<V>) -> Option<NodePtr<Lea
         // SAFETY: The iterator is limited to the lifetime of this function call and
         // does not escape. No other code mutates the referenced node, guaranteed by the
         // `minimum_unchecked` safey requirements and the reference.
-        let mut iter = unsafe { inner_node.into_iter() };
+        let mut iter = unsafe { inner_node.iter() };
         Some(iter.next()?.1)
     }
 
@@ -549,7 +549,7 @@ pub unsafe fn maximum_unchecked<V>(root: OpaqueNodePtr<V>) -> Option<NodePtr<Lea
         // SAFETY: The iterator is limited to the lifetime of this function call and
         // does not escape. No other code mutates the referenced node, guaranteed by the
         // `minimum_unchecked` safey requirements and the reference.
-        let iter = unsafe { inner_node.into_iter() };
+        let iter = unsafe { inner_node.iter() };
         Some(iter.last()?.1)
     }
 
@@ -625,7 +625,7 @@ impl<V> TrieRangeFullIter<V> {
         // pointers. The safety requirements on the `TrieRangeFullIter` type ensure that
         // no other mutation of the tree happens while the iterator is live.
         self.node_iters
-            .push_front(unsafe { inner.as_ref().into_iter().into() })
+            .push_front(unsafe { inner.as_ref().iter().into() })
     }
 
     fn update_iters_back<N: InnerNode<Value = V>>(&mut self, inner: NodePtr<N>) {
@@ -634,7 +634,7 @@ impl<V> TrieRangeFullIter<V> {
         // pointers. The safety requirements on the `TrieRangeFullIter` type ensure that
         // no other mutation of the tree happens while the iterator is live.
         self.node_iters
-            .push_back(unsafe { inner.as_ref().into_iter().into() })
+            .push_back(unsafe { inner.as_ref().iter().into() })
     }
 
     fn leaf_to_item(node: NodePtr<LeafNode<V>>) -> (*const [u8], *const V) {

--- a/src/nodes/operations.rs
+++ b/src/nodes/operations.rs
@@ -1,17 +1,23 @@
 //! Trie node lookup and manipulation
 
 use crate::{
-    ConcreteNodePtr, Header, InnerNode, InnerNode4, InnerNodeIter, LeafNode, NodePtr, OpaqueNodePtr,
+    ConcreteNodePtr, InnerNode, InnerNode4, InnerNodeIter, LeafNode, NodePtr, OpaqueNodePtr,
 };
-use std::{collections::VecDeque, error::Error, fmt::Display, iter};
+use std::{
+    collections::VecDeque,
+    error::Error,
+    fmt::{self, Display},
+    iter,
+    ops::ControlFlow,
+};
 
 /// Search in the given tree for the value stored with the given key.
 ///
 /// # Safety
 ///
-///   - This function cannot be called concurrently to any reads or writes of
-///     `root` or any child node of `root`. This function will arbitrarily read
-///     to any child in the given tree.
+///  - This function cannot be called concurrently with any mutating operation
+///    on `root` or any child node of `root`. This function will arbitrarily
+///    read to any child in the given tree.
 pub unsafe fn search_unchecked<V>(
     root: OpaqueNodePtr<V>,
     key: &[u8],
@@ -92,8 +98,7 @@ pub unsafe fn search_unchecked<V>(
 ///
 /// # Safety
 ///
-///  - The `root` [`OpaqueNodePtr`] must be a unique pointer to the underlying
-///    node object, otherwise a deallocation may create dangling pointers.
+///  - The `root` [`OpaqueNodePtr`] must be a unique pointer to the underlyin
 ///  - This function cannot be called concurrently to any reads or writes of the
 ///    `root` node or any child node of `root`. This function will arbitrarily
 ///    read or write to any child in the given tree.
@@ -102,37 +107,304 @@ pub unsafe fn insert_unchecked<V>(
     key: Box<[u8]>,
     value: V,
 ) -> Result<OpaqueNodePtr<V>, InsertError> {
-    enum TestResult<V> {
-        MismatchPrefix(OpaqueNodePtr<V>),
-        Error(InsertError),
-        Continue(u8, Box<[u8]>, V),
+    /// This struct contains the results from searching for an insert point for
+    /// a new node in the tree.
+    ///
+    /// It contains all the relevant information needed to perform the insert
+    /// and update the tree.
+    struct InsertSearchResult<V> {
+        parent_ptr_and_child_key_byte: Option<(OpaqueNodePtr<V>, u8)>,
+        insert_type: InsertSearchResultType<V>,
+        key_bytes_used: usize,
     }
 
-    fn test_prefix_update_depth_split_mismatch<V>(
+    /// The type of insert
+    enum InsertSearchResultType<V> {
+        /// An insert where an inner node had a differing prefix from the key.
+        ///
+        /// This insert type will create a new inner node with the portion of
+        /// the prefix that did match, and update the existing inner node
+        MismatchPrefix {
+            matched_prefix_size: usize,
+            mismatched_inner_node_ptr: OpaqueNodePtr<V>,
+        },
+        /// An insert where the node to be added matched all the way up to a
+        /// leaf node.
+        ///
+        /// This insert type will create a new inner node, and assign the
+        /// existing leaf and the new leaf as children to that node.
+        SplitLeaf { leaf_node_ptr: NodePtr<LeafNode<V>> },
+        /// An insert where the search terminated at an existing inner node that
+        /// did not have a child with the key byte.
+        ///
+        /// If the inner node is full, it will be grown to the next largest
+        /// size.
+        IntoExisting { inner_node_ptr: OpaqueNodePtr<V> },
+    }
+
+    impl<V> fmt::Debug for InsertSearchResultType<V> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::MismatchPrefix {
+                    matched_prefix_size,
+                    mismatched_inner_node_ptr,
+                } => f
+                    .debug_struct("MismatchPrefix")
+                    .field("matched_prefix_size", matched_prefix_size)
+                    .field("mismatched_inner_node_ptr", mismatched_inner_node_ptr)
+                    .finish(),
+                Self::SplitLeaf { leaf_node_ptr } => f
+                    .debug_struct("SplitLeaf")
+                    .field("leaf_node_ptr", leaf_node_ptr)
+                    .finish(),
+                Self::IntoExisting { inner_node_ptr } => f
+                    .debug_struct("IntoExisting")
+                    .field("inner_node_ptr", inner_node_ptr)
+                    .finish(),
+            }
+        }
+    }
+
+    /// Perform an iterative search for the insert point for the given key,
+    /// starting at the given root node.
+    fn search_for_insert_point<V>(
         root: OpaqueNodePtr<V>,
-        header: &mut Header,
-        key: Box<[u8]>,
-        value: V,
-        depth: &mut usize,
-    ) -> TestResult<V> {
-        // since header is mutable will need to write it back
-        let matched_prefix_size = header.match_prefix(&key[*depth..]);
-        if matched_prefix_size != header.prefix_size() {
+        key: &[u8],
+    ) -> Result<InsertSearchResult<V>, InsertError> {
+        fn test_prefix_identify_insert<V, N: InnerNode<Value = V>>(
+            inner_ptr: NodePtr<N>,
+            key: &[u8],
+            current_depth: &mut usize,
+        ) -> Result<ControlFlow<usize, Option<OpaqueNodePtr<V>>>, InsertError> {
+            // SAFETY: The lifetime produced from this is bounded to this scope and does not
+            // escape. Further, no other code mutates the node referenced, which is further
+            // enforced the "no concurrent reads or writes" requirement on the
+            // `search_unchecked` function.
+            let inner_node = unsafe { inner_ptr.as_ref() };
+            let header = inner_node.header();
+            let matched_prefix_size = header.match_prefix(&key[*current_depth..]);
+            if matched_prefix_size != header.prefix_size() {
+                return Ok(ControlFlow::Break(matched_prefix_size));
+            }
+
+            // Since the prefix matched, advance the depth by the size of the prefix
+            *current_depth += matched_prefix_size;
+
+            let next_key_fragment = if *current_depth < key.len() {
+                key[*current_depth]
+            } else {
+                // then the key has insufficient bytes to be unique. It must be
+                // a prefix of an existing key
+
+                return Err(InsertError::PrefixKey(Box::from(key)));
+            };
+
+            Ok(ControlFlow::Continue(
+                inner_node.lookup_child(next_key_fragment),
+            ))
+        }
+
+        let mut current_parent = None;
+        let mut current_node = root;
+        let mut current_depth = 0;
+
+        loop {
+            let lookup_result = match current_node.to_node_ptr() {
+                ConcreteNodePtr::Node4(inner_ptr) => {
+                    test_prefix_identify_insert(inner_ptr, key, &mut current_depth)
+                },
+                ConcreteNodePtr::Node16(inner_ptr) => {
+                    test_prefix_identify_insert(inner_ptr, key, &mut current_depth)
+                },
+                ConcreteNodePtr::Node48(inner_ptr) => {
+                    test_prefix_identify_insert(inner_ptr, key, &mut current_depth)
+                },
+                ConcreteNodePtr::Node256(inner_ptr) => {
+                    test_prefix_identify_insert(inner_ptr, key, &mut current_depth)
+                },
+                ConcreteNodePtr::LeafNode(leaf_node_ptr) => {
+                    return Ok(InsertSearchResult {
+                        key_bytes_used: current_depth,
+                        parent_ptr_and_child_key_byte: current_parent,
+                        insert_type: InsertSearchResultType::SplitLeaf { leaf_node_ptr },
+                    });
+                },
+            }?;
+
+            match lookup_result {
+                ControlFlow::Continue(next_child_node) => {
+                    match next_child_node {
+                        Some(next_child_node) => {
+                            current_parent = Some((current_node, key[current_depth]));
+                            current_node = next_child_node;
+                            // Increment by a single byte
+                            current_depth += 1;
+                        },
+                        None => {
+                            return Ok(InsertSearchResult {
+                                key_bytes_used: current_depth,
+                                insert_type: InsertSearchResultType::IntoExisting {
+                                    inner_node_ptr: current_node,
+                                },
+                                parent_ptr_and_child_key_byte: current_parent,
+                            })
+                        },
+                    }
+                },
+                ControlFlow::Break(matched_prefix_size) => {
+                    return Ok(InsertSearchResult {
+                        key_bytes_used: current_depth,
+                        insert_type: InsertSearchResultType::MismatchPrefix {
+                            matched_prefix_size,
+                            mismatched_inner_node_ptr: current_node,
+                        },
+                        parent_ptr_and_child_key_byte: current_parent,
+                    })
+                },
+            };
+        }
+    }
+
+    fn write_new_child_in_existing_node<V>(
+        inner_node_ptr: OpaqueNodePtr<V>,
+        new_leaf_node: LeafNode<V>,
+        key_bytes_used: usize,
+    ) -> OpaqueNodePtr<V> {
+        fn write_new_child_in_existing_inner_node<V, N: InnerNode<Value = V>>(
+            inner_node_ptr: NodePtr<N>,
+            new_leaf_node: LeafNode<V>,
+            key_bytes_used: usize,
+        ) -> OpaqueNodePtr<V> {
+            // SAFETY:
+            // You must enforce Rust’s aliasing rules, since the returned lifetime
+            // 'a is arbitrarily chosen and does not necessarily reflect the actual lifetime
+            // of the node. In particular, for the duration of this lifetime, the node the
+            // pointer points to must not get accessed (read or written) through any other
+            // pointer.
+            let inner_node = unsafe { inner_node_ptr.as_mut() };
+            let new_leaf_key_byte = new_leaf_node.key[key_bytes_used];
+            let new_leaf_ptr = NodePtr::allocate_node(new_leaf_node).to_opaque();
+            if inner_node.is_full() {
+                // we will create a new node of the next larger type and copy all the
+                // children over.
+
+                let mut new_node = inner_node.grow();
+                new_node.write_child(new_leaf_key_byte, new_leaf_ptr);
+
+                let new_inner_node = NodePtr::allocate_node(new_node).to_opaque();
+
+                // SAFETY: The `deallocate_node` function is only called a
+                // single time. The uniqueness requirement is passed up to the
+                // `grow_unchecked` safety requirements.
+                //
+                // Also, the `inner_node` mutable reference is invalid after this pointer and
+                // must not be used.
+                unsafe {
+                    NodePtr::deallocate_node(inner_node_ptr);
+                };
+
+                new_inner_node
+            } else {
+                inner_node.write_child(new_leaf_key_byte, new_leaf_ptr);
+
+                inner_node_ptr.to_opaque()
+            }
+        }
+
+        match inner_node_ptr.to_node_ptr() {
+            ConcreteNodePtr::Node4(inner_ptr) => {
+                write_new_child_in_existing_inner_node(inner_ptr, new_leaf_node, key_bytes_used)
+            },
+            ConcreteNodePtr::Node16(inner_ptr) => {
+                write_new_child_in_existing_inner_node(inner_ptr, new_leaf_node, key_bytes_used)
+            },
+            ConcreteNodePtr::Node48(inner_ptr) => {
+                write_new_child_in_existing_inner_node(inner_ptr, new_leaf_node, key_bytes_used)
+            },
+            ConcreteNodePtr::Node256(inner_ptr) => {
+                write_new_child_in_existing_inner_node(inner_ptr, new_leaf_node, key_bytes_used)
+            },
+            ConcreteNodePtr::LeafNode(_) => {
+                panic!("Cannot have insert into existing with leaf node")
+            },
+        }
+    }
+
+    /// Write a new child node to an inner node at the specified key byte.
+    fn parent_write_child<V>(
+        parent_inner_node: OpaqueNodePtr<V>,
+        key_byte: u8,
+        new_child: OpaqueNodePtr<V>,
+    ) {
+        fn write_inner_node<V, N: InnerNode<Value = V>>(
+            parent_inner_node: NodePtr<N>,
+            key_byte: u8,
+            new_child: OpaqueNodePtr<V>,
+        ) {
+            // SAFETY: The lifetime produced from this is bounded to this scope and does not
+            // escape. Further, no other code mutates the node referenced, which is further
+            // enforced the "no concurrent reads or writes" requirement on the
+            // `maximum_unchecked` function.
+            let parent_node = unsafe { parent_inner_node.as_mut() };
+
+            parent_node.write_child(key_byte, new_child)
+        }
+
+        match parent_inner_node.to_node_ptr() {
+            ConcreteNodePtr::Node4(inner_ptr) => write_inner_node(inner_ptr, key_byte, new_child),
+            ConcreteNodePtr::Node16(inner_ptr) => write_inner_node(inner_ptr, key_byte, new_child),
+            ConcreteNodePtr::Node48(inner_ptr) => write_inner_node(inner_ptr, key_byte, new_child),
+            ConcreteNodePtr::Node256(inner_ptr) => write_inner_node(inner_ptr, key_byte, new_child),
+            ConcreteNodePtr::LeafNode(_) => {
+                panic!("A leaf pointer cannot be the parent of another node")
+            },
+        }
+    }
+
+    if key.is_empty() {
+        return Err(InsertError::EmptyKey);
+    }
+
+    let InsertSearchResult {
+        parent_ptr_and_child_key_byte,
+        insert_type,
+        mut key_bytes_used,
+    } = search_for_insert_point(root, key.as_ref())?;
+
+    let new_inner_node = match insert_type {
+        InsertSearchResultType::MismatchPrefix {
+            matched_prefix_size,
+            mismatched_inner_node_ptr,
+        } => {
+            // SAFETY: The lifetime of the header reference is restricted to this block and
+            // within the block no other access occurs. The requirements of
+            // the "no concurrent (read or write) access" is also enforced by the
+            // `insert_unchecked` caller requirements.
+            //
+            // PANIC SAFETY: This is guaranteed not to panic because the `MismatchPrefix`
+            // variant is only returned in cases where there was a mismatch in the header
+            // prefix, implying that the header is present.
+            let header = unsafe { mismatched_inner_node_ptr.header_mut().unwrap() };
+
             // prefix mismatch, need to split prefix into two separate nodes and take the
             // common prefix into a new parent node
             let mut new_n4 = InnerNode4::empty();
 
-            if (*depth + matched_prefix_size) >= key.len() {
+            if (key_bytes_used + matched_prefix_size) >= key.len() {
                 // then the key has insufficient bytes to be unique. It must be
                 // a prefix of an existing key
 
-                return TestResult::Error(InsertError::PrefixKey(key));
+                return Err(InsertError::PrefixKey(key));
             }
 
-            let new_leaf_key_byte = key[*depth + matched_prefix_size];
+            let new_leaf_key_byte = key[key_bytes_used + matched_prefix_size];
+
             let new_leaf_pointer = NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque();
 
-            new_n4.write_child(header.read_prefix()[matched_prefix_size], root);
+            new_n4.write_child(
+                header.read_prefix()[matched_prefix_size],
+                mismatched_inner_node_ptr,
+            );
             new_n4.write_child(new_leaf_key_byte, new_leaf_pointer);
 
             new_n4
@@ -140,273 +412,58 @@ pub unsafe fn insert_unchecked<V>(
                 .write_prefix(&header.read_prefix()[..matched_prefix_size]);
             header.ltrim_prefix(matched_prefix_size + 1);
 
-            // Updated the header information here
-            return TestResult::MismatchPrefix(NodePtr::allocate_node(new_n4).to_opaque());
-        }
+            NodePtr::allocate_node(new_n4).to_opaque()
+        },
+        InsertSearchResultType::SplitLeaf { leaf_node_ptr } => {
+            let leaf_node = leaf_node_ptr.read();
 
-        *depth += header.prefix_size();
+            let mut new_n4 = InnerNode4::empty();
+            let prefix_size = leaf_node.key[key_bytes_used..]
+                .iter()
+                .zip(key[key_bytes_used..].iter())
+                .take_while(|(k1, k2)| k1 == k2)
+                .count();
+            new_n4
+                .header
+                .write_prefix(&key[key_bytes_used..(key_bytes_used + prefix_size)]);
+            key_bytes_used += prefix_size;
 
-        if *depth < key.len() {
-            TestResult::Continue(key[*depth], key, value)
-        } else {
-            TestResult::Error(InsertError::PrefixKey(key))
-        }
-    }
+            if key_bytes_used >= key.len() || key_bytes_used >= leaf_node.key.len() {
+                // then the key has insufficient bytes to be unique. It must be
+                // a prefix of an existing key OR an existing key is a prefix of it
 
-    // TODO: Consider an iterative solution to handle tree with long keys.
-    fn insert_rec_inner<V>(
-        mut root: OpaqueNodePtr<V>,
-        key: Box<[u8]>,
-        value: V,
-        mut depth: usize,
-    ) -> Result<OpaqueNodePtr<V>, InsertError> {
-        match root.to_node_ptr() {
-            ConcreteNodePtr::Node4(inner_ptr) => {
-                // SAFETY: The lifetime produced from this is bounded to this scope and does not
-                // escape. Further, no other code mutates or reads the node referenced, which is
-                // further enforced the "no concurrent reads or writes"
-                // requirement on the `insert_unchecked` function.
-                let inner_node = unsafe { inner_ptr.as_mut() };
-                let (next_key_fragment, key, value) = match test_prefix_update_depth_split_mismatch(
-                    root,
-                    &mut inner_node.header,
-                    key,
-                    value,
-                    &mut depth,
-                ) {
-                    TestResult::MismatchPrefix(new_node) => {
-                        return Ok(new_node);
-                    },
-                    TestResult::Error(error) => {
-                        return Err(error);
-                    },
-                    TestResult::Continue(next_key_fragment, key, value) => {
-                        (next_key_fragment, key, value)
-                    },
-                };
+                return Err(InsertError::PrefixKey(key));
+            }
 
-                match inner_node.lookup_child(next_key_fragment) {
-                    Some(next_child_node) => {
-                        let new_child = insert_rec_inner(next_child_node, key, value, depth + 1)?;
+            let new_leaf_key_byte = key[key_bytes_used];
+            let new_leaf_pointer = NodePtr::allocate_node(LeafNode::new(key, value));
 
-                        inner_node.write_child(next_key_fragment, new_child);
-                    },
-                    None => {
-                        if inner_node.is_full() {
-                            // we will create a new node of the next larger type and copy all the
-                            // children over.
+            new_n4.write_child(leaf_node.key[key_bytes_used], leaf_node_ptr.to_opaque());
+            new_n4.write_child(new_leaf_key_byte, new_leaf_pointer.to_opaque());
 
-                            let mut new_node = inner_node.grow();
-                            new_node.write_child(
-                                key[depth],
-                                NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                            );
+            NodePtr::allocate_node(new_n4).to_opaque()
+        },
+        InsertSearchResultType::IntoExisting { inner_node_ptr } => {
+            write_new_child_in_existing_node(
+                inner_node_ptr,
+                LeafNode::new(key, value),
+                key_bytes_used,
+            )
+        },
+    };
 
-                            root = NodePtr::allocate_node(new_node).to_opaque();
-                            // SAFETY: The `deallocate_node` function is only called a
-                            // single time. The uniqueness requirement is passed up to the
-                            // `grow_unchecked` safety requirements.
-                            unsafe {
-                                NodePtr::deallocate_node(inner_ptr);
-                            }
-                        } else {
-                            inner_node.write_child(
-                                key[depth],
-                                NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                            )
-                        }
-                    },
-                }
-            },
-            ConcreteNodePtr::Node16(inner_ptr) => {
-                // SAFETY: The lifetime produced from this is bounded to this scope and does not
-                // escape. Further, no other code mutates or reads the node referenced, which is
-                // further enforced the "no concurrent reads or writes"
-                // requirement on the `insert_unchecked` function.
-                let inner_node = unsafe { inner_ptr.as_mut() };
-                let (next_key_fragment, key, value) = match test_prefix_update_depth_split_mismatch(
-                    root,
-                    &mut inner_node.header,
-                    key,
-                    value,
-                    &mut depth,
-                ) {
-                    TestResult::MismatchPrefix(new_node) => {
-                        return Ok(new_node);
-                    },
-                    TestResult::Error(error) => {
-                        return Err(error);
-                    },
-                    TestResult::Continue(next_key_fragment, key, value) => {
-                        (next_key_fragment, key, value)
-                    },
-                };
+    if let Some((parent_ptr, parent_key_fragment)) = parent_ptr_and_child_key_byte {
+        parent_write_child(parent_ptr, parent_key_fragment, new_inner_node);
 
-                match inner_node.lookup_child(next_key_fragment) {
-                    Some(next_child_node) => {
-                        let new_child = insert_rec_inner(next_child_node, key, value, depth + 1)?;
-
-                        inner_node.write_child(next_key_fragment, new_child);
-                    },
-                    None => {
-                        if inner_node.is_full() {
-                            // we will create a new node of the next larger type and copy all the
-                            // children over.
-
-                            let mut new_node = inner_node.grow();
-                            new_node.write_child(
-                                key[depth],
-                                NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                            );
-
-                            root = NodePtr::allocate_node(new_node).to_opaque();
-                            // SAFETY: The `deallocate_node` function is only called a
-                            // single time. The uniqueness requirement is passed up to the
-                            // `grow_unchecked` safety requirements.
-                            unsafe {
-                                NodePtr::deallocate_node(inner_ptr);
-                            }
-                        } else {
-                            inner_node.write_child(
-                                key[depth],
-                                NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                            )
-                        }
-                    },
-                }
-            },
-            ConcreteNodePtr::Node48(inner_ptr) => {
-                // SAFETY: The lifetime produced from this is bounded to this scope and does not
-                // escape. Further, no other code mutates or reads the node referenced, which is
-                // further enforced the "no concurrent reads or writes"
-                // requirement on the `insert_unchecked` function.
-                let inner_node = unsafe { inner_ptr.as_mut() };
-                let (next_key_fragment, key, value) = match test_prefix_update_depth_split_mismatch(
-                    root,
-                    &mut inner_node.header,
-                    key,
-                    value,
-                    &mut depth,
-                ) {
-                    TestResult::MismatchPrefix(new_node) => {
-                        return Ok(new_node);
-                    },
-                    TestResult::Error(error) => {
-                        return Err(error);
-                    },
-                    TestResult::Continue(next_key_fragment, key, value) => {
-                        (next_key_fragment, key, value)
-                    },
-                };
-
-                match inner_node.lookup_child(next_key_fragment) {
-                    Some(next_child_node) => {
-                        let new_child = insert_rec_inner(next_child_node, key, value, depth + 1)?;
-
-                        inner_node.write_child(next_key_fragment, new_child);
-                    },
-                    None => {
-                        if inner_node.is_full() {
-                            // we will create a new node of the next larger type and copy all the
-                            // children over.
-
-                            let mut new_node = inner_node.grow();
-                            new_node.write_child(
-                                key[depth],
-                                NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                            );
-
-                            root = NodePtr::allocate_node(new_node).to_opaque();
-                            // SAFETY: The `deallocate_node` function is only called a
-                            // single time. The uniqueness requirement is passed up to the
-                            // `grow_unchecked` safety requirements.
-                            unsafe {
-                                NodePtr::deallocate_node(inner_ptr);
-                            }
-                        } else {
-                            inner_node.write_child(
-                                key[depth],
-                                NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                            )
-                        }
-                    },
-                }
-            },
-            ConcreteNodePtr::Node256(inner_ptr) => {
-                // SAFETY: The lifetime produced from this is bounded to this scope and does not
-                // escape. Further, no other code mutates or reads the node referenced, which is
-                // further enforced the "no concurrent reads or writes"
-                // requirement on the `insert_unchecked` function.
-                let inner_node = unsafe { inner_ptr.as_mut() };
-                let (next_key_fragment, key, value) = match test_prefix_update_depth_split_mismatch(
-                    root,
-                    &mut inner_node.header,
-                    key,
-                    value,
-                    &mut depth,
-                ) {
-                    TestResult::MismatchPrefix(new_node) => {
-                        return Ok(new_node);
-                    },
-                    TestResult::Error(error) => {
-                        return Err(error);
-                    },
-                    TestResult::Continue(next_key_fragment, key, value) => {
-                        (next_key_fragment, key, value)
-                    },
-                };
-
-                match inner_node.lookup_child(next_key_fragment) {
-                    Some(next_child_node) => {
-                        let new_child = insert_rec_inner(next_child_node, key, value, depth + 1)?;
-
-                        inner_node.write_child(next_key_fragment, new_child);
-                    },
-                    None => inner_node.write_child(
-                        key[depth],
-                        NodePtr::allocate_node(LeafNode::new(key, value)).to_opaque(),
-                    ),
-                }
-            },
-            ConcreteNodePtr::LeafNode(leaf_node_ptr) => {
-                let leaf_node = leaf_node_ptr.read();
-
-                let mut new_n4 = InnerNode4::empty();
-                let prefix_size = leaf_node.key[depth..]
-                    .iter()
-                    .zip(key[depth..].iter())
-                    .take_while(|(k1, k2)| k1 == k2)
-                    .count();
-                new_n4
-                    .header
-                    .write_prefix(&key[depth..(depth + prefix_size)]);
-                depth += prefix_size;
-
-                if depth >= key.len() || depth >= leaf_node.key.len() {
-                    // then the key has insufficient bytes to be unique. It must be
-                    // a prefix of an existing key OR an existing key is a prefix of it
-
-                    return Err(InsertError::PrefixKey(key));
-                }
-
-                let new_leaf_key_byte = key[depth];
-                let new_leaf_pointer = NodePtr::allocate_node(LeafNode::new(key, value));
-
-                new_n4.write_child(leaf_node.key[depth], root);
-                new_n4.write_child(new_leaf_key_byte, new_leaf_pointer.to_opaque());
-
-                return Ok(NodePtr::allocate_node(new_n4).to_opaque());
-            },
-        }
-
+        // If there was a parent either:
+        //   1. Root was the parent, in which case it was unchanged
+        //   2. Or some parent of the parent was root, in which case it was unchanged
         Ok(root)
+    } else {
+        // If there was no parent, then the root node was a leaf or the inner node split
+        // occurred at the root, in which case return the new inner node as root
+        Ok(new_inner_node)
     }
-
-    if key.is_empty() {
-        return Err(InsertError::EmptyKey);
-    }
-
-    insert_rec_inner(root, key, value, 0)
 }
 
 /// The error type for the insert operation on the tree.
@@ -490,9 +547,9 @@ pub unsafe fn deallocate_tree<V>(root: OpaqueNodePtr<V>) {
 ///
 /// # Safety
 ///
-///  - This function cannot be called concurrently to any reads or writes of
-///    `root` or any child node of `root`. This function will arbitrarily read
-///    to any child in the given tree.
+///  - This function cannot be called concurrently with any mutating operation
+///    on `root` or any child node of `root`. This function will arbitrarily
+///    read to any child in the given tree.
 pub unsafe fn minimum_unchecked<V>(root: OpaqueNodePtr<V>) -> Option<NodePtr<LeafNode<V>>> {
     fn get_next_node<N: InnerNode>(inner_node: NodePtr<N>) -> Option<OpaqueNodePtr<N::Value>> {
         // SAFETY: The lifetime produced from this is bounded to this scope and does not
@@ -535,9 +592,9 @@ pub unsafe fn minimum_unchecked<V>(root: OpaqueNodePtr<V>) -> Option<NodePtr<Lea
 ///
 /// # Safety
 ///
-///  - This function cannot be called concurrently to any reads or writes of
-///    `root` or any child node of `root`. This function will arbitrarily read
-///    to any child in the given tree.
+///  - This function cannot be called concurrently with any mutating operation
+///    on `root` or any child node of `root`. This function will arbitrarily
+///    read to any child in the given tree.
 pub unsafe fn maximum_unchecked<V>(root: OpaqueNodePtr<V>) -> Option<NodePtr<LeafNode<V>>> {
     fn get_next_node<N: InnerNode>(inner_node: NodePtr<N>) -> Option<OpaqueNodePtr<N::Value>> {
         // SAFETY: The lifetime produced from this is bounded to this scope and does not

--- a/src/nodes/operations.rs
+++ b/src/nodes/operations.rs
@@ -1,8 +1,7 @@
 //! Trie node lookup and manipulation
 
 use crate::{
-    ConcreteNodePtr, Header, InnerNode, InnerNode256Iter, InnerNode4, InnerNode48Iter,
-    InnerNodeCompressedIter, InnerNodeIter, LeafNode, NodePtr, OpaqueNodePtr,
+    ConcreteNodePtr, Header, InnerNode, InnerNode4, InnerNodeIter, LeafNode, NodePtr, OpaqueNodePtr,
 };
 use std::{collections::VecDeque, error::Error, fmt::Display, iter};
 
@@ -446,84 +445,38 @@ impl Error for InsertError {}
 ///  - This function must only be called once for this root node and all
 ///    descendants, otherwise a double-free could result.
 pub unsafe fn deallocate_tree<V>(root: OpaqueNodePtr<V>) {
+    fn deallocate_inner_node<V, N: InnerNode<Value = V>>(
+        stack: &mut Vec<OpaqueNodePtr<V>>,
+        inner_ptr: NodePtr<N>,
+    ) {
+        {
+            // SAFETY: The scope of this reference is bounded and we enforce that no
+            // mutation of the reference memory takes place within the lifetime. The
+            // deallocation of the node happens outside of this block, after the lifetime
+            // ends.
+            let inner_node = unsafe { inner_ptr.as_ref() };
+            // SAFETY: This iterator only lives for this block, a subset of the shared
+            // lifetime of the `inner_node` variable. By the safety requirements of the
+            // `deallocate_tree` function, no other mutation of this node can happen while
+            // this iterator is live.
+            let iter = unsafe { inner_node.into_iter() };
+            stack.extend(iter.map(|(_, child)| child));
+        }
+        // SAFETY: The single call per node requirement is enforced by the safety
+        // requirements on this function.
+        unsafe { NodePtr::deallocate_node(inner_ptr) }
+    }
+
     let mut stack = Vec::new();
 
     stack.push(root);
 
     while let Some(next_node_ptr) = stack.pop() {
         match next_node_ptr.to_node_ptr() {
-            ConcreteNodePtr::Node4(inner_ptr) => {
-                {
-                    // SAFETY: The scope of this reference is bounded and we enforce that no
-                    // mutation of the reference memory takes place within the lifetime. The
-                    // deallocation of the node happens outside of this block, after the lifetime
-                    // ends.
-                    let inner_node = unsafe { inner_ptr.as_ref() };
-                    // SAFETY: This iterator only lives for this block, a subset of the shared
-                    // lifetime of the `inner_node` variable. By the safety requirements of the
-                    // `deallocate_tree` function, no other mutation of this node can happen while
-                    // this iterator is live.
-                    let iter = unsafe { InnerNodeCompressedIter::new(inner_node) };
-                    stack.extend(iter.map(|(_, child)| child));
-                }
-                // SAFETY: The single call per node requirement is enforced by the safety
-                // requirements on this function.
-                unsafe { NodePtr::deallocate_node(inner_ptr) }
-            },
-            ConcreteNodePtr::Node16(inner_ptr) => {
-                {
-                    // SAFETY: The scope of this reference is bounded and we enforce that no
-                    // mutation of the reference memory takes place within the lifetime. The
-                    // deallocation of the node happens outside of this block, after the lifetime
-                    // ends.
-                    let inner_node = unsafe { inner_ptr.as_ref() };
-                    // SAFETY: This iterator only lives for this block, a subset of the shared
-                    // lifetime of the `inner_node` variable. By the safety requirements of the
-                    // `deallocate_tree` function, no other mutation of this node can happen while
-                    // this iterator is live.
-                    let iter = unsafe { InnerNodeCompressedIter::new(inner_node) };
-                    stack.extend(iter.map(|(_, child)| child));
-                }
-                // SAFETY: The single call per node requirement is enforced by the safety
-                // requirements on this function.
-                unsafe { NodePtr::deallocate_node(inner_ptr) }
-            },
-            ConcreteNodePtr::Node48(inner_ptr) => {
-                {
-                    // SAFETY: The scope of this reference is bounded and we enforce that no
-                    // mutation of the reference memory takes place within the lifetime. The
-                    // deallocation of the node happens outside of this block, after the lifetime
-                    // ends.
-                    let inner_node = unsafe { inner_ptr.as_ref() };
-                    // SAFETY: This iterator only lives for this block, a subset of the shared
-                    // lifetime of the `inner_node` variable. By the safety requirements of the
-                    // `deallocate_tree` function, no other mutation of this node can happen while
-                    // this iterator is live.
-                    let iter = unsafe { InnerNode48Iter::new(inner_node) };
-                    stack.extend(iter.map(|(_, child)| child));
-                }
-                // SAFETY: The single call per node requirement is enforced by the safety
-                // requirements on this function.
-                unsafe { NodePtr::deallocate_node(inner_ptr) }
-            },
-            ConcreteNodePtr::Node256(inner_ptr) => {
-                {
-                    // SAFETY: The scope of this reference is bounded and we enforce that no
-                    // mutation of the reference memory takes place within the lifetime. The
-                    // deallocation of the node happens outside of this block, after the lifetime
-                    // ends.
-                    let inner_node = unsafe { inner_ptr.as_ref() };
-                    // SAFETY: This iterator only lives for this block, a subset of the shared
-                    // lifetime of the `inner_node` variable. By the safety requirements of the
-                    // `deallocate_tree` function, no other mutation of this node can happen while
-                    // this iterator is live.
-                    let iter = unsafe { InnerNode256Iter::new(inner_node) };
-                    stack.extend(iter.map(|(_, child)| child));
-                }
-                // SAFETY: The single call per node requirement is enforced by the safety
-                // requirements on this function.
-                unsafe { NodePtr::deallocate_node(inner_ptr) }
-            },
+            ConcreteNodePtr::Node4(inner_ptr) => deallocate_inner_node(&mut stack, inner_ptr),
+            ConcreteNodePtr::Node16(inner_ptr) => deallocate_inner_node(&mut stack, inner_ptr),
+            ConcreteNodePtr::Node48(inner_ptr) => deallocate_inner_node(&mut stack, inner_ptr),
+            ConcreteNodePtr::Node256(inner_ptr) => deallocate_inner_node(&mut stack, inner_ptr),
             ConcreteNodePtr::LeafNode(inner) => {
                 // SAFETY: The single call per node requirement is enforced by the safety
                 // requirements on this function.

--- a/src/nodes/operations/insert_tests.rs
+++ b/src/nodes/operations/insert_tests.rs
@@ -47,10 +47,8 @@ fn insert_to_small_trees() {
 
 #[test]
 fn insert_into_left_skewed_tree_deallocate() {
-    // TODO(#1): Increase this back to `u8::MAX` after updating to an iterative
-    // insert algorithm.
     #[cfg(not(miri))]
-    const KEY_LENGTH_LIMIT: usize = (u8::MAX / 2) as usize;
+    const KEY_LENGTH_LIMIT: usize = u8::MAX as usize;
 
     #[cfg(miri)]
     const KEY_LENGTH_LIMIT: usize = 16usize;

--- a/src/nodes/representation.rs
+++ b/src/nodes/representation.rs
@@ -164,6 +164,12 @@ impl<V> fmt::Debug for OpaqueNodePtr<V> {
     }
 }
 
+impl<V> fmt::Pointer for OpaqueNodePtr<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.0, f)
+    }
+}
+
 impl<V> Eq for OpaqueNodePtr<V> {}
 
 impl<V> PartialEq for OpaqueNodePtr<V> {
@@ -389,6 +395,12 @@ impl<N: Node> fmt::Debug for NodePtr<N> {
     }
 }
 
+impl<N: Node> fmt::Pointer for NodePtr<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.0, f)
+    }
+}
+
 pub(crate) mod private {
     /// This trait is used to seal other traits, such that they cannot be
     /// implemented outside of the crate.
@@ -445,7 +457,7 @@ pub trait InnerNode: Node {
 
     /// Returns true if this node has no more space to store children.
     fn is_full(&self) -> bool {
-        Self::TYPE.upper_capacity() >= self.header().num_children()
+        self.header().num_children() >= Self::TYPE.upper_capacity()
     }
 
     /// Create an iterator over all (key bytes, child pointers) in this inner
@@ -645,7 +657,7 @@ impl<V> InnerNode for InnerNode4<V> {
     }
 
     unsafe fn iter(&self) -> Self::Iter {
-        // SAFETY: The safety requirements on the `into_iter` function match the `new`
+        // SAFETY: The safety requirements on the `iter` function match the `new`
         // function
         unsafe { InnerNodeCompressedIter::new(self) }
     }
@@ -685,7 +697,7 @@ impl<V> InnerNode for InnerNode16<V> {
     }
 
     unsafe fn iter(&self) -> Self::Iter {
-        // SAFETY: The safety requirements on the `into_iter` function match the `new`
+        // SAFETY: The safety requirements on the `iter` function match the `new`
         // function
         unsafe { InnerNodeCompressedIter::new(self) }
     }
@@ -854,7 +866,7 @@ impl<V> InnerNode for InnerNode48<V> {
     }
 
     unsafe fn iter(&self) -> Self::Iter {
-        // SAFETY: The safety requirements on the `into_iter` function match the `new`
+        // SAFETY: The safety requirements on the `iter` function match the `new`
         // function
         unsafe { InnerNode48Iter::new(self) }
     }
@@ -932,7 +944,7 @@ impl<V> InnerNode for InnerNode256<V> {
     }
 
     unsafe fn iter(&self) -> Self::Iter {
-        // SAFETY: The safety requirements on the `into_iter` function match the `new`
+        // SAFETY: The safety requirements on the `iter` function match the `new`
         // function
         unsafe { InnerNode256Iter::new(self) }
     }

--- a/src/nodes/representation.rs
+++ b/src/nodes/representation.rs
@@ -456,7 +456,7 @@ pub trait InnerNode: Node {
     /// The iterator type does not carry any lifetime, so the caller of this
     /// function must enforce that the lifetime of the iterator does not overlap
     /// with any mutating operations on the node.
-    unsafe fn into_iter(&self) -> Self::Iter;
+    unsafe fn iter(&self) -> Self::Iter;
 }
 
 /// Node type that has a compact representation for key bytes and children
@@ -644,7 +644,7 @@ impl<V> InnerNode for InnerNode4<V> {
         &mut self.header
     }
 
-    unsafe fn into_iter(&self) -> Self::Iter {
+    unsafe fn iter(&self) -> Self::Iter {
         // SAFETY: The safety requirements on the `into_iter` function match the `new`
         // function
         unsafe { InnerNodeCompressedIter::new(self) }
@@ -684,7 +684,7 @@ impl<V> InnerNode for InnerNode16<V> {
         &mut self.header
     }
 
-    unsafe fn into_iter(&self) -> Self::Iter {
+    unsafe fn iter(&self) -> Self::Iter {
         // SAFETY: The safety requirements on the `into_iter` function match the `new`
         // function
         unsafe { InnerNodeCompressedIter::new(self) }
@@ -853,7 +853,7 @@ impl<V> InnerNode for InnerNode48<V> {
         &mut self.header
     }
 
-    unsafe fn into_iter(&self) -> Self::Iter {
+    unsafe fn iter(&self) -> Self::Iter {
         // SAFETY: The safety requirements on the `into_iter` function match the `new`
         // function
         unsafe { InnerNode48Iter::new(self) }
@@ -931,7 +931,7 @@ impl<V> InnerNode for InnerNode256<V> {
         &mut self.header
     }
 
-    unsafe fn into_iter(&self) -> Self::Iter {
+    unsafe fn iter(&self) -> Self::Iter {
         // SAFETY: The safety requirements on the `into_iter` function match the `new`
         // function
         unsafe { InnerNode256Iter::new(self) }

--- a/src/nodes/representation/tests.rs
+++ b/src/nodes/representation/tests.rs
@@ -1,6 +1,5 @@
-use std::mem;
-
 use super::*;
+use std::mem;
 
 #[test]
 fn opaque_node_ptr_is_correct() {
@@ -119,6 +118,8 @@ fn node4_lookup() {
 #[test]
 fn node4_write_child() {
     let mut n = InnerNode4::empty();
+    assert!(!n.is_full());
+
     let mut l1 = LeafNode::new(vec![].into(), ());
     let mut l2 = LeafNode::new(vec![].into(), ());
     let mut l3 = LeafNode::new(vec![].into(), ());
@@ -141,6 +142,8 @@ fn node4_write_child() {
     assert_eq!(n.lookup_child(87), None);
     assert_eq!(n.lookup_child(u8::MIN), None);
     assert_eq!(n.lookup_child(u8::MAX), None);
+
+    assert!(n.is_full());
 }
 
 #[test]
@@ -233,6 +236,8 @@ fn node16_lookup() {
 fn node16_write_child() {
     let mut n = InnerNode16::empty();
     let mut leaves = vec![LeafNode::new(vec![].into(), ()); 16];
+
+    assert!(!n.is_full());
     {
         let leaf_pointers = leaves
             .iter_mut()
@@ -250,6 +255,7 @@ fn node16_write_child() {
             );
         }
     }
+    assert!(n.is_full());
 }
 
 #[test]
@@ -337,6 +343,8 @@ fn node48_lookup() {
 fn node48_write_child() {
     let mut n = InnerNode48::empty();
     let mut leaves = vec![LeafNode::new(vec![].into(), ()); 48];
+
+    assert!(!n.is_full());
     {
         let leaf_pointers = leaves
             .iter_mut()
@@ -354,6 +362,7 @@ fn node48_write_child() {
             );
         }
     }
+    assert!(n.is_full());
 }
 
 #[test]
@@ -448,6 +457,8 @@ fn node256_lookup() {
 fn node256_write_child() {
     let mut n = InnerNode256::empty();
     let mut leaves = vec![LeafNode::new(vec![].into(), ()); 256];
+
+    assert!(!n.is_full());
     {
         let leaf_pointers = leaves
             .iter_mut()
@@ -465,6 +476,7 @@ fn node256_write_child() {
             );
         }
     }
+    assert!(n.is_full());
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,7 +9,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 /// Setup a folder in the cargo `target/` directory that will hold dhat output
 /// files.
-pub fn setup_dhat_output_dir() -> PathBuf {
+fn setup_dhat_output_dir() -> PathBuf {
     const PARENT_OUTPUT_DIR: &str = "dhat-output/";
 
     let output_path = PathBuf::from(PARENT_OUTPUT_DIR);
@@ -19,6 +19,9 @@ pub fn setup_dhat_output_dir() -> PathBuf {
     output_path
 }
 
+/// Create DHAT output folder and generate output filename based on test
+/// filename.
+#[cfg_attr(miri, allow(dead_code))]
 pub fn generate_dhat_output_filename(test_filename: &str) -> PathBuf {
     let mut output_path = setup_dhat_output_dir();
 
@@ -34,6 +37,7 @@ pub fn generate_dhat_output_filename(test_filename: &str) -> PathBuf {
 }
 
 /// Initialize a [`dhat::Profiler`] for testing memory usage.
+#[cfg_attr(miri, allow(dead_code))]
 pub fn get_profiler(file_name: &str) -> dhat::Profiler {
     let output_path = generate_dhat_output_filename(file_name);
 
@@ -46,6 +50,7 @@ pub fn get_profiler(file_name: &str) -> dhat::Profiler {
 
 /// Safe context to run `dhat::assert_*` methods, guaranteed running
 /// [`dhat::Profiler`] and fresh [`dhat::HeapStats`]
+#[cfg_attr(miri, allow(dead_code))]
 pub fn test_heap<R>(_profiler: &dhat::Profiler, f: impl FnOnce(dhat::HeapStats) -> R) -> R {
     let stats = dhat::HeapStats::get();
 

--- a/tests/memory_usage_fixed_length_dense.rs
+++ b/tests/memory_usage_fixed_length_dense.rs
@@ -1,13 +1,13 @@
-#![feature(once_cell)]
-
 mod common;
-
-use blart::{deallocate_tree, insert_unchecked, search_unchecked, tests_common, LeafNode, NodePtr};
-use common::{get_profiler, test_heap};
 
 #[test]
 #[cfg(not(miri))]
 fn test_memory_usage() {
+    use blart::{
+        deallocate_tree, insert_unchecked, search_unchecked, tests_common, LeafNode, NodePtr,
+    };
+    use common::{get_profiler, test_heap};
+
     const KEY_LEVEL_WIDTH: [u8; 3] = [50, 1, 2];
 
     let keys: Vec<_> = tests_common::generate_key_fixed_length(KEY_LEVEL_WIDTH).collect();

--- a/tests/memory_usage_fixed_length_dense.rs
+++ b/tests/memory_usage_fixed_length_dense.rs
@@ -41,7 +41,7 @@ fn test_memory_usage() {
         dhat::assert_eq!(stats.curr_bytes, 0);
 
         dhat::assert_eq!(stats.max_blocks, 398);
-        dhat::assert_eq!(stats.max_bytes, 27584);
+        dhat::assert_eq!(stats.max_bytes, 17024);
 
         let num_keys = KEY_LEVEL_WIDTH
             .iter()

--- a/tests/memory_usage_large_prefixes.rs
+++ b/tests/memory_usage_large_prefixes.rs
@@ -14,7 +14,7 @@ fn test_memory_usage() {
     const PREFIX_EXPANSIONS: [PrefixExpansion; 2] = [
         PrefixExpansion {
             base_index: 0,
-            expanded_length: 3,
+            expanded_length: 9,
         },
         PrefixExpansion {
             base_index: 2,
@@ -55,8 +55,8 @@ fn test_memory_usage() {
         dhat::assert_eq!(stats.curr_blocks, 0);
         dhat::assert_eq!(stats.curr_bytes, 0);
 
-        dhat::assert_eq!(stats.max_blocks, 351);
-        dhat::assert_eq!(stats.max_bytes, 126264);
+        dhat::assert_eq!(stats.max_blocks, 359);
+        dhat::assert_eq!(stats.max_bytes, 126392);
 
         let num_keys = KEY_LEVEL_WIDTH
             .iter()

--- a/tests/memory_usage_large_prefixes.rs
+++ b/tests/memory_usage_large_prefixes.rs
@@ -1,14 +1,13 @@
-#![feature(once_cell)]
-
 mod common;
-
-use blart::{deallocate_tree, insert_unchecked, search_unchecked, tests_common, LeafNode, NodePtr};
-use common::{get_profiler, test_heap};
 
 #[test]
 #[cfg(not(miri))]
 fn test_memory_usage() {
-    use blart::tests_common::PrefixExpansion;
+    use blart::{
+        deallocate_tree, insert_unchecked, search_unchecked, tests_common,
+        tests_common::PrefixExpansion, LeafNode, NodePtr,
+    };
+    use common::{get_profiler, test_heap};
 
     const KEY_LEVEL_WIDTH: [u8; 3] = [6, 6, 5];
     const PREFIX_EXPANSIONS: [PrefixExpansion; 2] = [

--- a/tests/memory_usage_large_prefixes.rs
+++ b/tests/memory_usage_large_prefixes.rs
@@ -54,8 +54,8 @@ fn test_memory_usage() {
         dhat::assert_eq!(stats.curr_blocks, 0);
         dhat::assert_eq!(stats.curr_bytes, 0);
 
-        dhat::assert_eq!(stats.max_blocks, 359);
-        dhat::assert_eq!(stats.max_bytes, 126392);
+        dhat::assert_eq!(stats.max_blocks, 360);
+        dhat::assert_eq!(stats.max_bytes, 17280);
 
         let num_keys = KEY_LEVEL_WIDTH
             .iter()

--- a/tests/memory_usage_skewed.rs
+++ b/tests/memory_usage_skewed.rs
@@ -1,13 +1,13 @@
-#![feature(once_cell)]
-
 mod common;
-
-use blart::{deallocate_tree, insert_unchecked, search_unchecked, tests_common, LeafNode, NodePtr};
-use common::{get_profiler, test_heap};
 
 #[test]
 #[cfg(not(miri))]
 fn test_memory_usage() {
+    use blart::{
+        deallocate_tree, insert_unchecked, search_unchecked, tests_common, LeafNode, NodePtr,
+    };
+    use common::{get_profiler, test_heap};
+
     // TODO(#1): Increase this back to `u8::MAX` after updating to an iterative
     // insert algorithm.
     const KEY_LENGTH_LIMIT: usize = (u8::MAX / 2) as usize;

--- a/tests/memory_usage_skewed.rs
+++ b/tests/memory_usage_skewed.rs
@@ -8,9 +8,7 @@ fn test_memory_usage() {
     };
     use common::{get_profiler, test_heap};
 
-    // TODO(#1): Increase this back to `u8::MAX` after updating to an iterative
-    // insert algorithm.
-    const KEY_LENGTH_LIMIT: usize = (u8::MAX / 2) as usize;
+    const KEY_LENGTH_LIMIT: usize = u8::MAX as usize;
 
     let keys: Vec<_> = tests_common::generate_keys_skewed(KEY_LENGTH_LIMIT).collect();
 
@@ -43,8 +41,8 @@ fn test_memory_usage() {
         dhat::assert_eq!(stats.curr_blocks, 0);
         dhat::assert_eq!(stats.curr_bytes, 0);
 
-        dhat::assert_eq!(stats.max_blocks, 255);
-        dhat::assert_eq!(stats.max_bytes, 12498);
+        dhat::assert_eq!(stats.max_blocks, 511);
+        dhat::assert_eq!(stats.max_bytes, 25170);
 
         let mean_blocks_per_key = (stats.max_blocks as f64) / (KEY_LENGTH_LIMIT as f64);
         let mean_bytes_per_key = (stats.max_bytes as f64) / (KEY_LENGTH_LIMIT as f64);


### PR DESCRIPTION
Closes #1 . Implements iterative insert with a 2 part function:
1. Find the insert point and record information that is required to update the tree (parent node, number of key bytes used, etc)
2. Insert the new leaf in the tree and update existing nodes (like parent or sibling inner nodes)

This PR also updates some of the unit tests which had constrained their key sizes to prevent stack overflow and other general improvements.