### PR TITLE
Add optional support for custom TreeMap allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+ - Add an optional feature to allow custom allocator support for use with collections. If the `nightly` feature flag is enabled and the `nightly` toolchain is used, then any type which implements `std::alloc::Allocator` can be used as the custom allocator. If the `allocator-api2` feature flag is enabled, then any type which implements `allocator_api2::alloc::Allocator` can be used as the custom allocator.
+    - The `nightly` feature flag takes precedence over the `allocator-api2` feature flag.
+    - The `allocator-api2` feature flag works on stable, while the `nightly` feature flag does not.
+
 ### Changed
 
 ### Removed
 
- - Remove the `TreeMap::{try_entry_ref, entry_ref}` functions. The value add of `*entry_ref` was that you could pass a `&Q` to do the lookup, just like the `get` method allows. On insert, then the `&Q` would be converted to a `K`. I didn't think the value of that delayed conversion was worth keeping the whole module around, since you can emulate the `entry*` interface using `get`/`insert` calls directly.
+ - Removed the `TreeMap::{try_entry_ref, entry_ref}` functions. The value of `*entry_ref` was that you could pass a `&Q` to do the lookup, just like the `get` method. Then on insert, the `&Q` would be converted to a `K`. I didn't think the value of that delayed conversion was worth keeping the whole module around, since you can emulate the `entry*` interface using `get`/`insert` calls directly.
  - Removed the glob import of the `nodes` module from the top-level of the crate. Most of the types that were there previously can now be found under the `raw` module (which was renamed from `nodes` internally).
 
 ## [0.3.0] - 2024-09-21

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,14 @@ exclude = [
 autobenches = false
 
 [dependencies]
+allocator-api2 = { version = "0.2.20", optional = true }
 bytemuck = { version = "1.16.1", features = ["min_const_generics"] }
 paste = "1.0.15"
 
 [features]
 nightly = []
 bench-perf-events = []
+allocator-api2 = ["dep:allocator-api2"]
 
 [dev-dependencies]
 argh = "0.1.12"
@@ -40,6 +42,7 @@ dhat = "0.3.3"
 rand = "0.8.5"
 iai-callgrind = "0.13.4"
 zipf = "7.0.1"
+bumpalo = { version = "3.16.0", features = ["allocator-api2"] }
 
 [[bench]]
 name = "criterion"

--- a/benches/tree/iter.rs
+++ b/benches/tree/iter.rs
@@ -62,7 +62,7 @@ fn bench(c: &mut Criterion) {
     });
 
     group.bench_function("dict/range", |b| {
-        let range = get_middle_key(&tree, 1, 2)..get_middle_key(&tree, 2, 1);
+        let range = get_middle_key(tree, 1, 2)..get_middle_key(tree, 2, 1);
         b.iter(|| {
             tree.range::<CString, _>(range.clone()).for_each(|(k, v)| {
                 std::hint::black_box((k, v));

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -14,30 +14,30 @@ fi
 TOOLCHAIN="${1}"
 TOOLCHAIN_ARG="+${TOOLCHAIN}"
 
-
 if [ "${TOOLCHAIN}" = "nightly" ]; then
-    TOOLCHAIN_EXTRA_ARGS="--features nightly"
+    declare -a TOOLCHAIN_EXTRA_ARGS=("" "--all-features")
 else
-    TOOLCHAIN_EXTRA_ARGS=""
+    declare -a TOOLCHAIN_EXTRA_ARGS=("" "--features allocator-api2")
 fi
 
-cargo "${TOOLCHAIN_ARG}" fmt -- --check
-cargo "${TOOLCHAIN_ARG}" build  $TOOLCHAIN_EXTRA_ARGS --all-targets
+for extra_args in "${TOOLCHAIN_EXTRA_ARGS[@]}"
+do
+    cargo "${TOOLCHAIN_ARG}" fmt -- --check
+    cargo "${TOOLCHAIN_ARG}" build  $extra_args --all-targets
 
-# --all-targets does not include the doctests
-cargo "${TOOLCHAIN_ARG}" test   $TOOLCHAIN_EXTRA_ARGS --lib --bins --examples --tests
-# check in release just in case
-cargo "${TOOLCHAIN_ARG}" test   $TOOLCHAIN_EXTRA_ARGS --lib --bins --examples --tests --release
-# We test benchmarks in release, otherwise they are too slow
-cargo "${TOOLCHAIN_ARG}" test   $TOOLCHAIN_EXTRA_ARGS --benches --release
-cargo "${TOOLCHAIN_ARG}" test   $TOOLCHAIN_EXTRA_ARGS --doc
+    # --all-targets does not include the doctests
+    cargo "${TOOLCHAIN_ARG}" test   $extra_args --lib --bins --examples --tests
+    # check in release just in case
+    cargo "${TOOLCHAIN_ARG}" test   $extra_args --lib --bins --examples --tests --release
+    # We test benchmarks in release, otherwise they are too slow
+    cargo "${TOOLCHAIN_ARG}" test   $extra_args --benches --release
+    cargo "${TOOLCHAIN_ARG}" test   $extra_args --doc
 
-cargo "${TOOLCHAIN_ARG}" clippy $TOOLCHAIN_EXTRA_ARGS --all-targets 
-cargo "${TOOLCHAIN_ARG}" doc    $TOOLCHAIN_EXTRA_ARGS --no-deps --document-private-items
+    cargo "${TOOLCHAIN_ARG}" clippy $extra_args --all-targets 
+    cargo "${TOOLCHAIN_ARG}" doc    $extra_args --no-deps --document-private-items
 
-if [ "${TOOLCHAIN}" = "nightly" ]; then
-    # Test with and without the toolchain-specific features
-    # Also don't test benchmarks, since those load from disk
-    cargo "${TOOLCHAIN_ARG}" miri test --lib --bins --examples --tests $TOOLCHAIN_EXTRA_ARGS
-    cargo "${TOOLCHAIN_ARG}" miri test --lib --bins --examples --tests
-fi
+    if [ "${TOOLCHAIN}" = "nightly" ]; then
+        cargo "${TOOLCHAIN_ARG}" miri test --lib --bins --examples --tests $extra_args
+    fi
+done
+

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,0 +1,111 @@
+pub(crate) use self::inner::{do_alloc, Allocator, Global};
+
+#[cfg(all(test, any(feature = "nightly", feature = "allocator-api2")))]
+pub(crate) use self::inner::AllocError;
+
+// Nightly-case.
+// Use unstable `allocator_api` feature.
+// This is compatible with `allocator-api2` which can be enabled or not.
+// This is used when building for `std`.
+#[cfg(feature = "nightly")]
+mod inner {
+    pub use std::alloc::{Allocator, Global};
+    use std::{alloc::Layout, ptr::NonNull};
+
+    #[cfg(test)]
+    pub use std::alloc::AllocError;
+
+    #[allow(clippy::map_err_ignore)]
+    pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        match alloc.allocate(layout) {
+            Ok(ptr) => Ok(ptr.as_non_null_ptr()),
+            Err(_) => Err(()),
+        }
+    }
+}
+
+// Basic non-nightly case.
+// This uses `allocator-api2` enabled by default.
+// If any crate enables "nightly" in `allocator-api2`,
+// this will be equivalent to the nightly case,
+// since `allocator_api2::alloc::Allocator` would be re-export of
+// `core::alloc::Allocator`.
+#[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
+mod inner {
+    pub use allocator_api2::alloc::{Allocator, Global};
+    use std::{alloc::Layout, ptr::NonNull};
+
+    #[cfg(test)]
+    pub use allocator_api2::alloc::AllocError;
+
+    #[allow(clippy::map_err_ignore)]
+    pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        match alloc.allocate(layout) {
+            Ok(ptr) => Ok(ptr.cast()),
+            Err(_) => Err(()),
+        }
+    }
+}
+
+// No-defaults case.
+// When building with default-features turned off and
+// neither `nightly` nor `allocator-api2` is enabled,
+// this will be used.
+// Making it impossible to use any custom allocator with collections defined
+// in this crate.
+// Any crate in build-tree can enable `allocator-api2`,
+// or `nightly` without disturbing users that don't want to use it.
+#[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
+mod inner {
+    use std::{
+        alloc::{alloc, dealloc, Layout},
+        ptr::NonNull,
+    };
+
+    #[allow(clippy::missing_safety_doc)] // not exposed outside of this crate
+    pub unsafe trait Allocator {
+        /// Attempts to allocate a block of memory.
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()>;
+
+        /// Deallocates the memory referenced by `ptr`.
+        ///
+        /// # Safety
+        ///
+        /// * `ptr` must denote a block of memory [*currently allocated*] via
+        ///   this allocator, and
+        /// * `layout` must [*fit*] that block of memory.
+        ///
+        /// [*currently allocated*]: https://doc.rust-lang.org/std/alloc/trait.Allocator.html#currently-allocated-memory
+        /// [*fit*]: https://doc.rust-lang.org/std/alloc/trait.Allocator.html#memory-fitting
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
+    }
+
+    /// The global memory allocator.
+    #[derive(Copy, Clone)]
+    pub struct Global;
+
+    unsafe impl Allocator for Global {
+        #[inline]
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()> {
+            unsafe { NonNull::new(alloc(layout)).ok_or(()) }
+        }
+
+        #[inline]
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            unsafe { dealloc(ptr.as_ptr(), layout) };
+        }
+    }
+
+    impl Default for Global {
+        #[inline]
+        fn default() -> Self {
+            Global
+        }
+    }
+
+    /// Allocate a block of memory that fits the given layout using the given
+    /// allocator.
+    pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        alloc.allocate(layout)
+    }
+}

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -251,7 +251,7 @@ impl AsBytes for PathBuf {
 #[cfg(any(unix, target_os = "wasi"))]
 unsafe impl OrderedBytes for PathBuf {}
 
-impl<'a, B> AsBytes for Cow<'a, B>
+impl<B> AsBytes for Cow<'_, B>
 where
     B: ToOwned + AsBytes + ?Sized,
 {
@@ -280,7 +280,7 @@ where
 {
 }
 
-impl<'a, T> AsBytes for &'a T
+impl<T> AsBytes for &T
 where
     T: AsBytes + ?Sized,
 {
@@ -292,14 +292,14 @@ where
 // SAFETY: This trait is safe to implement because the underlying
 // type is already implements `OrderedBytes`, and the `Ord` impl works the same
 // way
-unsafe impl<'a, T> OrderedBytes for &'a T where T: OrderedBytes + ?Sized {}
+unsafe impl<T> OrderedBytes for &T where T: OrderedBytes + ?Sized {}
 
 // SAFETY: This trait is safe to implement because the underlying
 // type is already implements `NoPrefixesBytes`, and the wrapper type would not
 // change that property
-unsafe impl<'a, T> NoPrefixesBytes for &'a T where T: NoPrefixesBytes + ?Sized {}
+unsafe impl<T> NoPrefixesBytes for &T where T: NoPrefixesBytes + ?Sized {}
 
-impl<'a, T> AsBytes for &'a mut T
+impl<T> AsBytes for &mut T
 where
     T: AsBytes + ?Sized,
 {
@@ -311,12 +311,12 @@ where
 // SAFETY: This trait is safe to implement because the underlying
 // type is already implements `OrderedBytes`, and the `Ord` impl works the same
 // way
-unsafe impl<'a, T> OrderedBytes for &'a mut T where T: OrderedBytes + ?Sized {}
+unsafe impl<T> OrderedBytes for &mut T where T: OrderedBytes + ?Sized {}
 
 // SAFETY: This trait is safe to implement because the underlying
 // type is already implements `NoPrefixesBytes`, and the wrapper type would not
 // change that property
-unsafe impl<'a, T> NoPrefixesBytes for &'a mut T where T: NoPrefixesBytes + ?Sized {}
+unsafe impl<T> NoPrefixesBytes for &mut T where T: NoPrefixesBytes + ?Sized {}
 
 impl<T> AsBytes for Rc<T>
 where
@@ -394,13 +394,13 @@ unsafe impl<T> OrderedBytes for ManuallyDrop<T> where T: OrderedBytes + ?Sized {
 // change that property
 unsafe impl<T> NoPrefixesBytes for ManuallyDrop<T> where T: NoPrefixesBytes + ?Sized {}
 
-impl<'a> AsBytes for IoSlice<'a> {
+impl AsBytes for IoSlice<'_> {
     fn as_bytes(&self) -> &[u8] {
         self
     }
 }
 
-impl<'a> AsBytes for IoSliceMut<'a> {
+impl AsBytes for IoSliceMut<'_> {
     fn as_bytes(&self) -> &[u8] {
         self
     }
@@ -471,19 +471,15 @@ mod tests {
             b"hello world"
         );
         assert_eq!(
-            <CStr as AsBytes>::as_bytes(CStr::from_bytes_with_nul(b"hello world\0").unwrap()),
+            <CStr as AsBytes>::as_bytes(c"hello world"),
             b"hello world\0"
         );
         assert_eq!(
-            <CString as AsBytes>::as_bytes(
-                &CStr::from_bytes_with_nul(b"hello world\0").unwrap().into()
-            ),
+            <CString as AsBytes>::as_bytes(&c"hello world".into()),
             b"hello world\0"
         );
         assert_eq!(
-            <CString as AsBytes>::as_bytes(
-                &CStr::from_bytes_with_nul(b"hello world\0").unwrap().into()
-            ),
+            <CString as AsBytes>::as_bytes(&c"hello world".into()),
             b"hello world\0"
         );
         #[cfg(any(unix, target_os = "wasi"))]

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -2,6 +2,7 @@
 //! iterators/etc.
 
 use crate::{
+    alloc::{Allocator, Global},
     raw::{
         clone_unchecked, deallocate_tree, find_maximum_to_delete, find_minimum_to_delete,
         maximum_unchecked, minimum_unchecked, search_for_delete_point, search_for_insert_point,
@@ -18,6 +19,7 @@ use std::{
     hash::Hash,
     mem::ManuallyDrop,
     ops::{Index, RangeBounds},
+    ptr,
 };
 
 mod entry;
@@ -25,14 +27,18 @@ mod iterators;
 pub use entry::*;
 pub use iterators::*;
 
-const DEFAULT_PREFIX_LEN: usize = 16;
+/// This is the default number of bytes that are used in each inner node for
+/// storing key prefixes.
+pub const DEFAULT_PREFIX_LEN: usize = 16;
 
 /// An ordered map based on an adaptive radix tree.
-pub struct TreeMap<K, V, const PREFIX_LEN: usize = DEFAULT_PREFIX_LEN> {
+pub struct TreeMap<K, V, const PREFIX_LEN: usize = DEFAULT_PREFIX_LEN, A: Allocator = Global> {
     /// The number of entries present in the tree.
     num_entries: usize,
     /// A pointer to the tree root, if present.
     pub(crate) state: Option<NonEmptyTree<K, V, PREFIX_LEN>>,
+    /// The allocator which will be used to alloc and dealloc tree nodes.
+    alloc: A,
 }
 
 pub(crate) struct NonEmptyTree<K, V, const PREFIX_LEN: usize> {
@@ -42,7 +48,7 @@ pub(crate) struct NonEmptyTree<K, V, const PREFIX_LEN: usize> {
 }
 
 impl<K, V> TreeMap<K, V> {
-    /// Create a new, empty [`crate::TreeMap`] with the default number of prefix
+    /// Create a new, empty [`TreeMap`] with the default number of prefix
     /// bytes (16).
     ///
     /// This function will not pre-allocate anything.
@@ -61,94 +67,65 @@ impl<K, V> TreeMap<K, V> {
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
-    /// Create a new, empty [`crate::TreeMap`].
+impl<K, V, A: Allocator> TreeMap<K, V, DEFAULT_PREFIX_LEN, A> {
+    /// Create a new, empty [`TreeMap`] with the default number of prefix bytes
+    /// (16), which will allocate tree nodes using the given allocator.
     ///
     /// This function will not pre-allocate anything.
+    #[cfg_attr(
+        any(feature = "nightly", feature = "allocator-api2"),
+        doc = r##"
+# Examples
+
+```rust
+use blart::{TreeMap, map::DEFAULT_PREFIX_LEN};
+use std::alloc::System;
+
+let mut map = TreeMap::<_, i32, DEFAULT_PREFIX_LEN, _>::new_in(System);
+assert!(map.is_empty());
+map.insert(c"abc", 0);
+assert_eq!(*map.get(c"abc").unwrap(), 0);
+```
+    "##
+    )]
+    pub fn new_in(alloc: A) -> Self {
+        Self::with_prefix_len_in(alloc)
+    }
+}
+
+impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
+    /// Create a new, empty [`TreeMap`] with a non-default node prefix
+    /// length.
+    ///
+    /// This function will not pre-allocate anything. The prefix length is
+    /// inferred as a const-generic parameter on the type.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use blart::TreeMap;
     ///
-    /// let map = TreeMap::<Box<[u8]>, (), 16>::with_prefix_len();
-    /// assert_eq!(map, TreeMap::new());
+    /// let map = TreeMap::<Box<[u8]>, (), 8>::with_prefix_len();
     /// assert!(map.is_empty());
     /// ```
     pub fn with_prefix_len() -> Self {
         TreeMap {
             num_entries: 0,
             state: None,
+            alloc: Global,
         }
-    }
-
-    /// Clear the map, removing all elements.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use blart::TreeMap;
-    ///
-    /// let mut map = TreeMap::<Box<[u8]>, char>::new();
-    ///
-    /// map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
-    /// assert_eq!(map.len(), 1);
-    ///
-    /// map.clear();
-    /// assert!(map.is_empty());
-    /// assert!(map.get([1, 2, 3].as_ref()).is_none());
-    /// ```
-    pub fn clear(&mut self) {
-        if let Some(state) = &mut self.state {
-            // SAFETY: Since we have a mutable reference to the map, we know that there are
-            // no other mutable references to any node in the tree, meaning we can
-            // deallocate all of them.
-            unsafe {
-                deallocate_tree(state.root);
-            }
-
-            self.num_entries = 0;
-            self.state = None;
-        }
-    }
-
-    /// Consume the tree, returning a raw pointer to the root node.
-    ///
-    /// If the results is `None`, this means the tree is empty.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use blart::TreeMap;
-    ///
-    /// let mut map = TreeMap::<Box<[u8]>, char>::new();
-    ///
-    /// map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
-    /// assert_eq!(map.len(), 1);
-    ///
-    /// let root = TreeMap::into_raw(map);
-    /// assert!(root.is_some());
-    ///
-    /// // SAFETY: The root pointer came directly from the `into_raw` result.
-    /// let _map = unsafe { TreeMap::from_raw(root) }.unwrap();
-    /// ```
-    pub fn into_raw(tree: Self) -> Option<OpaqueNodePtr<K, V, PREFIX_LEN>> {
-        // We need this `ManuallyDrop` so that the `TreeMap::drop` is not called.
-        // Since the `root` field is `Copy`, it can be moved out of the tree without
-        // inhibiting `Drop`
-        let tree = ManuallyDrop::new(tree);
-        tree.state.as_ref().map(|state| state.root)
     }
 
     /// Constructs a [`TreeMap`] from a raw node pointer.
     ///
     /// # Safety
     ///
-    /// The raw pointer must have been previously returned by a call to
-    /// [`TreeMap::into_raw`].
-    ///
-    /// This function also requires that this the given `root` pointer is
-    /// unique, and that there are no other pointers into the tree.
+    ///  - The raw pointer must have been previously returned by a call to
+    ///    [`TreeMap::into_raw_with_allocator`] or [`TreeMap::into_raw`].
+    ///     - The allocator of the previous tree must have been the "default"
+    ///       allocator named `Global`.
+    ///  - The given `root` pointer must be unique and there are no other
+    ///    pointers into the tree.
     ///
     /// # Errors
     ///
@@ -178,6 +155,222 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     where
         K: AsBytes,
     {
+        // SAFETY: The safety requirement of `from_raw_in` are a superset of the ones on
+        // `from_raw`.
+        unsafe { Self::from_raw_in(root, Global) }
+    }
+}
+
+impl<K, V, const PREFIX_LEN: usize, A: Allocator> TreeMap<K, V, PREFIX_LEN, A> {
+    /// Returns a reference to the underlying allocator.
+    #[cfg_attr(
+        any(feature = "nightly", feature = "allocator-api2"),
+        doc = r##"
+# Examples
+
+```rust
+use blart::{TreeMap, map::DEFAULT_PREFIX_LEN};
+use std::alloc::System;
+
+let map = TreeMap::<Box<[u8]>, i32, DEFAULT_PREFIX_LEN, _>::new_in(System);
+assert!(matches!(map.allocator(), &System));
+```
+    "##
+    )]
+    pub fn allocator(&self) -> &A {
+        &self.alloc
+    }
+
+    /// Create a new, empty [`TreeMap`] with a non-default node prefix
+    /// length, and the given allocator for allocating tree nodes.
+    ///
+    /// This function will not pre-allocate anything. The prefix length is
+    /// inferred as a const-generic parameter on the type.
+    #[cfg_attr(
+        any(feature = "nightly", feature = "allocator-api2"),
+        doc = r##"
+# Examples
+
+```rust
+use blart::TreeMap;
+use std::alloc::System;
+
+let map = TreeMap::<Box<[u8]>, i32, 8, _>::with_prefix_len_in(System);
+assert!(matches!(map.allocator(), &System));
+```
+    "##
+    )]
+    pub fn with_prefix_len_in(alloc: A) -> Self {
+        TreeMap {
+            num_entries: 0,
+            state: None,
+            alloc,
+        }
+    }
+
+    /// Clear the map, removing all elements.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use blart::TreeMap;
+    ///
+    /// let mut map = TreeMap::<Box<[u8]>, char>::new();
+    ///
+    /// map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
+    /// assert_eq!(map.len(), 1);
+    ///
+    /// map.clear();
+    /// assert!(map.is_empty());
+    /// assert!(map.get([1, 2, 3].as_ref()).is_none());
+    /// ```
+    pub fn clear(&mut self) {
+        if let Some(state) = &mut self.state {
+            // SAFETY:
+            //  - Since we have a mutable reference to the map, we know that there are no
+            //    other mutable references to any node in the tree, meaning we can
+            //    deallocate all of them.
+            //  - `self.alloc` was used to allocate all the nodes of the trie
+            unsafe {
+                deallocate_tree(state.root, &self.alloc);
+            }
+
+            self.num_entries = 0;
+            self.state = None;
+        }
+    }
+
+    /// Consume the tree, returning a raw pointer to the root node.
+    ///
+    /// If the results is `None`, this means the tree is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use blart::TreeMap;
+    ///
+    /// let mut map = TreeMap::<Box<[u8]>, char>::new();
+    ///
+    /// map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
+    /// assert_eq!(map.len(), 1);
+    ///
+    /// let root = TreeMap::into_raw(map);
+    /// assert!(root.is_some());
+    ///
+    /// // SAFETY: The root pointer came directly from the `into_raw` result.
+    /// let _map = unsafe { TreeMap::from_raw(root) }.unwrap();
+    /// ```
+    pub fn into_raw(tree: Self) -> Option<OpaqueNodePtr<K, V, PREFIX_LEN>> {
+        Self::into_raw_with_allocator(tree).0
+    }
+
+    /// Consume the tree, returning a raw pointer to the root node and the
+    /// allocator of the tree.
+    ///
+    /// If the results is `None`, this means the tree is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use blart::TreeMap;
+    ///
+    /// let mut map = TreeMap::<Box<[u8]>, char>::new();
+    ///
+    /// map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
+    /// assert_eq!(map.len(), 1);
+    ///
+    /// let (root, alloc) = TreeMap::into_raw_with_allocator(map);
+    /// assert!(root.is_some());
+    ///
+    /// // SAFETY: The root pointer came directly from the `into_raw` result.
+    /// let _map = unsafe { TreeMap::from_raw_in(root, alloc) }.unwrap();
+    /// ```
+    pub fn into_raw_with_allocator(tree: Self) -> (Option<OpaqueNodePtr<K, V, PREFIX_LEN>>, A) {
+        // We need this `ManuallyDrop` so that the `TreeMap::drop` is not called.
+        // Since the `root` field is `Copy`, it can be moved out of the tree without
+        // inhibiting `Drop`
+        let tree = ManuallyDrop::new(tree);
+        // SAFETY: Since we're reading from an `&A` that was coerced to a `*const A` we
+        // know that the pointer is valid for reads, properly aligned, and properly
+        // initialized.
+        //
+        // Also this is safe from a double-free since we're using `ManuallyDrop` to
+        // inhibit the first copy of `A` (in the `tree` value) from doing anything.
+        let alloc = unsafe { ptr::read(&tree.alloc) };
+        let root = tree.state.as_ref().map(|state| state.root);
+
+        (root, alloc)
+    }
+
+    /// Constructs a [`TreeMap`] from a raw node pointer and the given
+    /// allocator.
+    ///
+    /// # Safety
+    ///
+    ///  - The raw pointer must have been previously returned by a call to
+    ///    [`TreeMap::into_raw_with_allocator`] or [`TreeMap::into_raw`] with a
+    ///    known allocator.
+    ///  - The given `root` pointer must be unique and there are no other
+    ///    pointers into the tree.
+    ///  - The given `alloc` must have been used to allocate all of the nodes
+    ///    referenced by the given `root` pointer.
+    ///
+    /// # Errors
+    ///
+    /// This function runs a series of checks to ensure that the returned tree
+    /// is well-formed. See [`WellFormedChecker`] for details on the
+    /// requirements.
+    #[cfg_attr(
+        any(feature = "nightly", feature = "allocator-api2"),
+        doc = r##"
+# Examples
+
+Using the [`TreeMap::into_raw`] function to get the root node pointer:
+
+```rust
+use blart::{TreeMap, map::DEFAULT_PREFIX_LEN};
+use std::alloc::System;
+
+let mut map = TreeMap::<Box<[u8]>, char, DEFAULT_PREFIX_LEN, _>::new_in(System);
+
+map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
+assert_eq!(map.len(), 1);
+assert!(matches!(map.allocator(), &System));
+
+let root = TreeMap::into_raw(map);
+assert!(root.is_some());
+
+// SAFETY: The root pointer came directly from the `into_raw` result.
+let _map = unsafe { TreeMap::from_raw_in(root, System) }.unwrap();
+```
+
+Using the [`TreeMap::into_raw_with_allocator`] function to get the root
+node pointer and allocator:
+
+```rust
+use blart::TreeMap;
+
+let mut map = TreeMap::<Box<[u8]>, char>::new();
+
+map.try_insert(Box::new([1, 2, 3]), 'a').unwrap();
+assert_eq!(map.len(), 1);
+
+let (root, alloc) = TreeMap::into_raw_with_allocator(map);
+
+assert!(root.is_some());
+
+// SAFETY: The root pointer came directly from the `into_raw` result.
+let _map = unsafe { TreeMap::from_raw_in(root, alloc) }.unwrap();
+```
+    "##
+    )]
+    pub unsafe fn from_raw_in(
+        root: Option<OpaqueNodePtr<K, V, PREFIX_LEN>>,
+        alloc: A,
+    ) -> Result<Self, MalformedTreeError<K, V, PREFIX_LEN>>
+    where
+        K: AsBytes,
+    {
         match root {
             Some(root) => {
                 // SAFETY: The safety doc of this function guarantees the uniqueness of the
@@ -196,9 +389,10 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
                         max_leaf,
                     }),
                     num_entries: stats.num_leaf,
+                    alloc,
                 })
             },
-            None => Ok(Self::with_prefix_len()),
+            None => Ok(Self::with_prefix_len_in(alloc)),
         }
     }
 
@@ -340,7 +534,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
         &'a self,
         key: &'b Q,
         max_edit_dist: usize,
-    ) -> Fuzzy<'a, 'b, K, V, PREFIX_LEN>
+    ) -> Fuzzy<'a, 'b, K, V, PREFIX_LEN, A>
     where
         K: Borrow<Q> + AsBytes,
         Q: AsBytes + ?Sized,
@@ -372,7 +566,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
         &'a mut self,
         key: &'b Q,
         max_edit_dist: usize,
-    ) -> FuzzyMut<'a, 'b, K, V, PREFIX_LEN>
+    ) -> FuzzyMut<'a, 'b, K, V, PREFIX_LEN, A>
     where
         K: Borrow<Q> + AsBytes,
         Q: AsBytes + ?Sized,
@@ -527,7 +721,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
 
     fn init_tree(&mut self, key: K, value: V) -> NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>> {
         // Since this is a singleton tree, the single leaf node has no siblings
-        let leaf = NodePtr::allocate_node_ptr(LeafNode::with_no_siblings(key, value));
+        let leaf = NodePtr::allocate_node_ptr(LeafNode::with_no_siblings(key, value), &self.alloc);
         let state = NonEmptyTree {
             root: leaf.to_opaque(),
             min_leaf: leaf,
@@ -547,9 +741,11 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     where
         K: AsBytes,
     {
-        // SAFETY: This call is safe because we have a mutable reference on the tree, so
-        // no other operation can be concurrent with this one.
-        let insert_result = unsafe { insert_point.apply(key, value) };
+        // SAFETY:
+        //  - This call is safe because we have a mutable reference on the tree, so no
+        //    other operation can be concurrent with this one.
+        //  - The same allocator is used for all inserts and deletes
+        let insert_result = unsafe { insert_point.apply(key, value, &self.alloc) };
 
         match &mut self.state {
             Some(state) => {
@@ -590,12 +786,15 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
         &mut self,
         delete_point: DeletePoint<K, V, PREFIX_LEN>,
     ) -> DeleteResult<K, V, PREFIX_LEN> {
-        // SAFETY: The root is sure to not be `None`, since the we somehow got a
-        // `DeletePoint`. So the caller must have checked this. Also, since we have a
-        // mutable reference to the tree, no other read or write operation can be
-        // happening concurrently.
+        // SAFETY:
+        // - The root is sure to not be `None`, since the we somehow got a
+        //   `DeletePoint`. So the caller must have checked this. Also, since we have a
+        //   mutable reference to the tree, no other read or write operation can be
+        //   happening concurrently.
+        // - `self.alloc` is the same allocator which is used for all inserts and
+        //   deletes on this trie
         let delete_result =
-            unsafe { delete_point.apply(self.state.as_ref().unwrap_unchecked().root) };
+            unsafe { delete_point.apply(self.state.as_ref().unwrap_unchecked().root, &self.alloc) };
 
         match &mut self.state {
             Some(state) => {
@@ -835,7 +1034,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// }
     /// assert_eq!(map.range(&4..).next(), Some((&5, &"b")));
     /// ```
-    pub fn range<Q, R>(&self, range: R) -> iterators::Range<K, V, PREFIX_LEN>
+    pub fn range<Q, R>(&self, range: R) -> iterators::Range<K, V, PREFIX_LEN, A>
     where
         Q: AsBytes + ?Sized,
         K: Borrow<Q> + AsBytes,
@@ -885,7 +1084,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(map["Carol"], 200);
     /// assert_eq!(map["Cheryl"], 200);
     /// ```
-    pub fn range_mut<Q, R>(&mut self, range: R) -> iterators::RangeMut<K, V, PREFIX_LEN>
+    pub fn range_mut<Q, R>(&mut self, range: R) -> iterators::RangeMut<K, V, PREFIX_LEN, A>
     where
         Q: AsBytes + ?Sized,
         K: Borrow<Q> + AsBytes,
@@ -927,7 +1126,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     // assert_eq!(b[[41].as_ref()], "e");
     // ```
     #[allow(dead_code)]
-    pub(crate) fn split_off<Q>(&mut self, split_key: &Q) -> TreeMap<K, V, PREFIX_LEN>
+    pub(crate) fn split_off<Q>(&mut self, split_key: &Q) -> TreeMap<K, V, PREFIX_LEN, A>
     where
         K: Borrow<Q> + AsBytes,
         Q: AsBytes + ?Sized,
@@ -1007,7 +1206,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(iter.next().unwrap(), 4);
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn into_keys(self) -> iterators::IntoKeys<K, V, PREFIX_LEN> {
+    pub fn into_keys(self) -> iterators::IntoKeys<K, V, PREFIX_LEN, A> {
         iterators::IntoKeys::new(self)
     }
 
@@ -1033,7 +1232,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(iter.next().unwrap(), 'z');
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn into_values(self) -> iterators::IntoValues<K, V, PREFIX_LEN> {
+    pub fn into_values(self) -> iterators::IntoValues<K, V, PREFIX_LEN, A> {
         iterators::IntoValues::new(self)
     }
 
@@ -1057,7 +1256,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(iter.next().unwrap(), (&4, &'z'));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn iter(&self) -> Iter<'_, K, V, PREFIX_LEN> {
+    pub fn iter(&self) -> Iter<'_, K, V, PREFIX_LEN, A> {
         Iter::new(self)
     }
 
@@ -1082,7 +1281,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(map[&3], 'A');
     /// assert_eq!(map[&4], 'Z');
     /// ```
-    pub fn iter_mut(&mut self) -> IterMut<'_, K, V, PREFIX_LEN> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V, PREFIX_LEN, A> {
         IterMut::new(self)
     }
 
@@ -1106,7 +1305,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(iter.next().unwrap(), &4);
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn keys(&self) -> Keys<'_, K, V, PREFIX_LEN> {
+    pub fn keys(&self) -> Keys<'_, K, V, PREFIX_LEN, A> {
         Keys::new(self)
     }
 
@@ -1130,7 +1329,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(iter.next().unwrap(), &'z');
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn values(&self) -> Values<'_, K, V, PREFIX_LEN> {
+    pub fn values(&self) -> Values<'_, K, V, PREFIX_LEN, A> {
         Values::new(self)
     }
 
@@ -1155,7 +1354,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     /// assert_eq!(map[&3], 'A');
     /// assert_eq!(map[&4], 'Z');
     /// ```
-    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V, PREFIX_LEN> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V, PREFIX_LEN, A> {
         ValuesMut::new(self)
     }
 
@@ -1178,7 +1377,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     ///
     /// assert_eq!(p, vec![(&c"abcde", &0), (&c"abcdexxx", &0), (&c"abcdexxy", &0)]);
     /// ```
-    pub fn prefix(&self, prefix: &[u8]) -> Prefix<'_, K, V, PREFIX_LEN>
+    pub fn prefix(&self, prefix: &[u8]) -> Prefix<'_, K, V, PREFIX_LEN, A>
     where
         K: AsBytes,
     {
@@ -1205,7 +1404,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     ///
     /// assert_eq!(p, vec![(&c"abcde", &mut 0), (&c"abcdexxx", &mut 0), (&c"abcdexxy", &mut 0)]);
     /// ```
-    pub fn prefix_mut(&mut self, prefix: &[u8]) -> PrefixMut<'_, K, V, PREFIX_LEN>
+    pub fn prefix_mut(&mut self, prefix: &[u8]) -> PrefixMut<'_, K, V, PREFIX_LEN, A>
     where
         K: AsBytes,
     {
@@ -1244,10 +1443,10 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
+impl<K, V, const PREFIX_LEN: usize, A: Allocator> TreeMap<K, V, PREFIX_LEN, A> {
     /// Tries to get the given key’s corresponding entry in the map for in-place
     /// manipulation.
-    pub fn try_entry(&mut self, key: K) -> Result<Entry<K, V, PREFIX_LEN>, InsertPrefixError>
+    pub fn try_entry(&mut self, key: K) -> Result<Entry<K, V, PREFIX_LEN, A>, InsertPrefixError>
     where
         K: AsBytes,
     {
@@ -1284,7 +1483,7 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
 
     /// Gets the given key’s corresponding entry in the map for in-place
     /// manipulation.
-    pub fn entry(&mut self, key: K) -> Entry<'_, K, V, PREFIX_LEN>
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V, PREFIX_LEN, A>
     where
         K: NoPrefixesBytes,
     {
@@ -1293,16 +1492,17 @@ impl<K, V, const PREFIX_LEN: usize> TreeMap<K, V, PREFIX_LEN> {
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Drop for TreeMap<K, V, PREFIX_LEN> {
+impl<K, V, const PREFIX_LEN: usize, A: Allocator> Drop for TreeMap<K, V, PREFIX_LEN, A> {
     fn drop(&mut self) {
         self.clear();
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Clone for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> Clone for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Clone + AsBytes,
     V: Clone,
+    A: Allocator + Clone,
 {
     fn clone(&self) -> Self {
         match &self.state {
@@ -1311,7 +1511,7 @@ where
                     root,
                     min_leaf,
                     max_leaf,
-                } = unsafe { clone_unchecked(state.root) };
+                } = unsafe { clone_unchecked(state.root, &self.alloc) };
 
                 TreeMap {
                     num_entries: self.num_entries,
@@ -1320,20 +1520,23 @@ where
                         min_leaf,
                         max_leaf,
                     }),
+                    alloc: self.alloc.clone(),
                 }
             },
             None => TreeMap {
                 num_entries: 0,
                 state: None,
+                alloc: self.alloc.clone(),
             },
         }
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Debug for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> Debug for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Debug,
     V: Debug,
+    A: Allocator,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map().entries(self.iter()).finish()
@@ -1346,10 +1549,11 @@ impl<K, V, const PREFIX_LEN: usize> Default for TreeMap<K, V, PREFIX_LEN> {
     }
 }
 
-impl<'a, K, V, const PREFIX_LEN: usize> Extend<(&'a K, &'a V)> for TreeMap<K, V, PREFIX_LEN>
+impl<'a, K, V, A, const PREFIX_LEN: usize> Extend<(&'a K, &'a V)> for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Copy + NoPrefixesBytes,
     V: Copy,
+    A: Allocator,
 {
     fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: T) {
         for (key, value) in iter {
@@ -1358,9 +1562,10 @@ where
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Extend<(K, V)> for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> Extend<(K, V)> for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: NoPrefixesBytes,
+    A: Allocator,
 {
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         for (key, value) in iter {
@@ -1395,10 +1600,11 @@ where
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Hash for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> Hash for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Hash,
     V: Hash,
+    A: Allocator,
 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         hasher_write_length_prefix(state, self.num_entries);
@@ -1408,10 +1614,11 @@ where
     }
 }
 
-impl<Q, K, V, const PREFIX_LEN: usize> Index<&Q> for TreeMap<K, V, PREFIX_LEN>
+impl<Q, K, V, A, const PREFIX_LEN: usize> Index<&Q> for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Borrow<Q> + AsBytes,
     Q: AsBytes + ?Sized,
+    A: Allocator,
 {
     type Output = V;
 
@@ -1420,8 +1627,10 @@ where
     }
 }
 
-impl<'a, K, V, const PREFIX_LEN: usize> IntoIterator for &'a TreeMap<K, V, PREFIX_LEN> {
-    type IntoIter = Iter<'a, K, V, PREFIX_LEN>;
+impl<'a, K, V, const PREFIX_LEN: usize, A: Allocator> IntoIterator
+    for &'a TreeMap<K, V, PREFIX_LEN, A>
+{
+    type IntoIter = Iter<'a, K, V, PREFIX_LEN, A>;
     type Item = (&'a K, &'a V);
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1429,8 +1638,10 @@ impl<'a, K, V, const PREFIX_LEN: usize> IntoIterator for &'a TreeMap<K, V, PREFI
     }
 }
 
-impl<'a, K, V, const PREFIX_LEN: usize> IntoIterator for &'a mut TreeMap<K, V, PREFIX_LEN> {
-    type IntoIter = IterMut<'a, K, V, PREFIX_LEN>;
+impl<'a, K, V, const PREFIX_LEN: usize, A: Allocator> IntoIterator
+    for &'a mut TreeMap<K, V, PREFIX_LEN, A>
+{
+    type IntoIter = IterMut<'a, K, V, PREFIX_LEN, A>;
     type Item = (&'a K, &'a mut V);
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1438,8 +1649,8 @@ impl<'a, K, V, const PREFIX_LEN: usize> IntoIterator for &'a mut TreeMap<K, V, P
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> IntoIterator for TreeMap<K, V, PREFIX_LEN> {
-    type IntoIter = iterators::IntoIter<K, V, PREFIX_LEN>;
+impl<K, V, const PREFIX_LEN: usize, A: Allocator> IntoIterator for TreeMap<K, V, PREFIX_LEN, A> {
+    type IntoIter = iterators::IntoIter<K, V, PREFIX_LEN, A>;
     type Item = (K, V);
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1447,37 +1658,41 @@ impl<K, V, const PREFIX_LEN: usize> IntoIterator for TreeMap<K, V, PREFIX_LEN> {
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Ord for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> Ord for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Ord,
     V: Ord,
+    A: Allocator,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.iter().cmp(other.iter())
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> PartialOrd for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> PartialOrd for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: PartialOrd,
     V: PartialOrd,
+    A: Allocator,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.iter().partial_cmp(other.iter())
     }
 }
 
-impl<K, V, const PREFIX_LEN: usize> Eq for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> Eq for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Eq,
     V: Eq,
+    A: Allocator,
 {
 }
 
-impl<K, V, const PREFIX_LEN: usize> PartialEq for TreeMap<K, V, PREFIX_LEN>
+impl<K, V, A, const PREFIX_LEN: usize> PartialEq for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: PartialEq,
     V: PartialEq,
+    A: Allocator,
 {
     fn eq(&self, other: &Self) -> bool {
         self.num_entries == other.num_entries && self.iter().eq(other.iter())
@@ -1487,20 +1702,22 @@ where
 // SAFETY: This is safe to implement if `K` and `V` are also `Send`.
 // This container is safe to `Send` for the same reasons why other container
 // are also safe
-unsafe impl<K, V, const PREFIX_LEN: usize> Send for TreeMap<K, V, PREFIX_LEN>
+unsafe impl<K, V, A, const PREFIX_LEN: usize> Send for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Send,
     V: Send,
+    A: Send + Allocator,
 {
 }
 
 // SAFETY: This is safe to implement if `K` and `V` are also `Sync`.
 // This container is safe to `Sync` for the same reasons why other container
 // are also safe
-unsafe impl<K, V, const PREFIX_LEN: usize> Sync for TreeMap<K, V, PREFIX_LEN>
+unsafe impl<K, V, A, const PREFIX_LEN: usize> Sync for TreeMap<K, V, PREFIX_LEN, A>
 where
     K: Sync,
     V: Sync,
+    A: Sync + Allocator,
 {
 }
 
@@ -1982,5 +2199,179 @@ mod tests {
         tree.clear();
         assert_eq!(tree.len(), 0);
         assert_eq!(tree.pop_first(), None);
+    }
+}
+
+#[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+mod custom_allocator_tests {
+    use super::*;
+
+    use crate::{
+        alloc::AllocError,
+        rust_nightly_apis::ptr::{nonnull_addr, nonnull_with_addr},
+    };
+
+    use std::{
+        alloc::Layout,
+        cell::{Cell, UnsafeCell},
+        marker::PhantomPinned,
+        mem::MaybeUninit,
+        num::NonZeroUsize,
+        pin::Pin,
+        ptr::{addr_of_mut, NonNull},
+    };
+
+    struct BumpAllocator<const N: usize> {
+        block: UnsafeCell<MaybeUninit<[u8; N]>>,
+
+        // Points to start of block
+        start: Cell<NonNull<u8>>,
+        // Points to end of block
+        end: Cell<NonNull<u8>>,
+        // Points somewhere between `start` and `end`, is
+        // the end of the next allocation
+        ptr: Cell<NonNull<u8>>,
+
+        alloc_count: Cell<usize>,
+        dealloc_count: Cell<usize>,
+
+        // Prevent Unpin
+        _marker: PhantomPinned,
+    }
+
+    impl<const N: usize> BumpAllocator<N> {
+        fn new() -> Pin<Box<Self>> {
+            let mut alloc = Box::new(Self {
+                block: UnsafeCell::new(MaybeUninit::uninit()),
+
+                // These three will be fixed up after allocating the allocator
+                start: Cell::new(NonNull::dangling()),
+                end: Cell::new(NonNull::dangling()),
+                ptr: Cell::new(NonNull::dangling()),
+
+                alloc_count: Cell::new(0),
+                dealloc_count: Cell::new(0),
+
+                _marker: PhantomPinned,
+            });
+
+            let alloc_start = NonNull::new(addr_of_mut!((*alloc).block).cast::<u8>()).unwrap();
+            alloc.start.set(alloc_start);
+            alloc
+                .end
+                .set(unsafe { alloc_start.offset(N.try_into().unwrap()) });
+            alloc.ptr.set(alloc.end.get());
+
+            Box::into_pin(alloc)
+        }
+    }
+
+    unsafe impl<const N: usize> Allocator for Pin<Box<BumpAllocator<N>>> {
+        #[inline]
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            self.alloc_count.set(self.alloc_count.get() + 1);
+
+            let size = layout.size();
+            let align = layout.align();
+
+            debug_assert!(align > 0);
+            debug_assert!(align.is_power_of_two());
+
+            let ptr = nonnull_addr(self.ptr.get());
+
+            let new_ptr = ptr.get().checked_sub(size).unwrap();
+
+            // Round down to the requested alignment.
+            let new_ptr = NonZeroUsize::new(new_ptr & !(align - 1)).unwrap();
+
+            let start = nonnull_addr(self.start.get());
+            if new_ptr < start {
+                // Didn't have enough capacity!
+                return Err(AllocError);
+            }
+
+            self.ptr.set(nonnull_with_addr(self.ptr.get(), new_ptr));
+            Ok(NonNull::slice_from_raw_parts(self.ptr.get(), size))
+        }
+
+        #[inline]
+        unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
+            self.dealloc_count.set(self.dealloc_count.get() + 1);
+        }
+    }
+
+    // Just a simple test to make sure the allocator works as expected outside of
+    // the tree
+    #[test]
+    fn non_tree_allocation() {
+        let allocator = BumpAllocator::<64>::new();
+
+        let ptr = allocator.allocate(Layout::new::<[u8; 32]>());
+        assert!(ptr.is_ok());
+        let ptr = allocator.allocate(Layout::new::<[u8; 32]>());
+        assert!(ptr.is_ok());
+        let ptr = allocator.allocate(Layout::new::<[u8; 1]>());
+        assert!(ptr.is_err());
+        let ptr = allocator.allocate(Layout::new::<[u8; 0]>());
+        assert!(ptr.is_ok());
+
+        assert_eq!(allocator.alloc_count.get(), 4);
+        assert_eq!(allocator.dealloc_count.get(), 0);
+    }
+
+    #[test]
+    fn small_tree() {
+        let allocator = BumpAllocator::<
+            {
+                std::mem::size_of::<
+                    crate::raw::InnerNode4<
+                        &std::ffi::CStr,
+                        i32,
+                        { crate::map::DEFAULT_PREFIX_LEN },
+                    >,
+                >() + (2 * std::mem::size_of::<
+                    crate::raw::LeafNode<&std::ffi::CStr, i32, { crate::map::DEFAULT_PREFIX_LEN }>,
+                >())
+            },
+        >::new();
+
+        let mut tree = TreeMap::new_in(allocator);
+        tree.insert(c"abc", 0);
+        tree.insert(c"xyz", 1);
+        assert_eq!(tree.get(c"abc").unwrap(), &0);
+        assert_eq!(tree.get(c"xyz").unwrap(), &1);
+
+        let (root, allocator) = TreeMap::into_raw_with_allocator(tree);
+
+        // 1 Node4, 2 LeafNodes
+        // assert_eq!(allocator.alloc_count.get(), 3);
+        // assert_eq!(allocator.dealloc_count.get(), 0);
+
+        unsafe {
+            deallocate_tree(root.unwrap(), &allocator);
+        }
+
+        // Each node alloc and dealloced
+        // assert_eq!(allocator.alloc_count.get(), 3);
+        // assert_eq!(allocator.dealloc_count.get(), 3);
+    }
+
+    struct EmptyAllocator;
+
+    unsafe impl Allocator for EmptyAllocator {
+        #[inline]
+        fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            Err(AllocError)
+        }
+
+        #[inline]
+        unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+    }
+
+    #[test]
+    #[should_panic(expected = "memory is infinite")]
+    fn out_of_memory() {
+        let mut tree = TreeMap::new_in(EmptyAllocator);
+        tree.insert(c"abc", 0);
     }
 }

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -2255,11 +2255,12 @@ mod custom_allocator_tests {
                 _marker: PhantomPinned,
             });
 
-            let alloc_start = NonNull::new(addr_of_mut!((*alloc).block).cast::<u8>()).unwrap();
+            let alloc_start = NonNull::new(addr_of_mut!(alloc.block).cast::<u8>()).unwrap();
             alloc.start.set(alloc_start);
-            alloc
-                .end
-                .set(unsafe { alloc_start.offset(N.try_into().unwrap()) });
+            alloc.end.set(
+                NonNull::new(unsafe { alloc_start.as_ptr().offset(N.try_into().unwrap()) })
+                    .unwrap(),
+            );
             alloc.ptr.set(alloc.end.get());
 
             Box::into_pin(alloc)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
 #![cfg_attr(
     feature = "nightly",
     feature(
+        allocator_api,
+        core_intrinsics,
+        hasher_prefixfree_extras,
         impl_trait_in_assoc_type,
+        maybe_uninit_array_assume_init,
         maybe_uninit_slice,
         maybe_uninit_uninit_array,
-        maybe_uninit_array_assume_init,
+        portable_simd,
         slice_ptr_get,
-        hasher_prefixfree_extras,
-        core_intrinsics,
-        portable_simd
     )
 )]
 #![cfg_attr(feature = "nightly", allow(incomplete_features, internal_features))]
@@ -39,6 +40,7 @@
 //!
 //! [ART paper]: http://web.archive.org/web/20240508000744/https://db.in.tum.de/~leis/papers/ART.pdf
 
+mod alloc;
 mod bytes;
 mod collections;
 mod rust_nightly_apis;

--- a/src/raw/operations/minmax.rs
+++ b/src/raw/operations/minmax.rs
@@ -53,6 +53,7 @@ pub unsafe fn maximum_unchecked<K, V, const PREFIX_LEN: usize>(
 #[cfg(test)]
 mod tests {
     use crate::{
+        alloc::Global,
         raw::{
             deallocate_tree, maximum_unchecked, minimum_unchecked, LeafNode, NodePtr, OpaqueNodePtr,
         },
@@ -63,6 +64,7 @@ mod tests {
     fn leaf_tree_min_max_same() {
         let root: OpaqueNodePtr<Box<[i32; 4]>, String, 16> = NodePtr::allocate_node_ptr(
             LeafNode::with_no_siblings(Box::new([1, 2, 3, 4]), "1234".to_string()),
+            &Global,
         )
         .to_opaque();
 
@@ -71,7 +73,7 @@ mod tests {
 
         assert_eq!(min_leaf, max_leaf);
 
-        unsafe { deallocate_tree(root) }
+        unsafe { deallocate_tree(root, &Global) }
     }
 
     #[test]
@@ -82,9 +84,11 @@ mod tests {
         const VALUE_STOPS: u8 = 2;
 
         let mut keys = generate_key_fixed_length([VALUE_STOPS; 3]);
-        let mut root: OpaqueNodePtr<[u8; 3], usize, 16> =
-            NodePtr::allocate_node_ptr(LeafNode::with_no_siblings(keys.next().unwrap(), 0))
-                .to_opaque();
+        let mut root: OpaqueNodePtr<[u8; 3], usize, 16> = NodePtr::allocate_node_ptr(
+            LeafNode::with_no_siblings(keys.next().unwrap(), 0),
+            &Global,
+        )
+        .to_opaque();
 
         for (idx, key) in keys.enumerate() {
             root = unsafe { insert_unchecked(root, key, idx + 1).unwrap().new_root };
@@ -104,16 +108,18 @@ mod tests {
             assert_eq!(max_leaf.key_ref().as_ref(), &[5, 5, 5]);
         }
 
-        unsafe { deallocate_tree(root) }
+        unsafe { deallocate_tree(root, &Global) }
     }
 
     #[test]
     fn skewed_tree_min_max() {
         let mut keys = generate_keys_skewed(12);
 
-        let mut root: OpaqueNodePtr<Box<[u8]>, usize, 16> =
-            NodePtr::allocate_node_ptr(LeafNode::with_no_siblings(keys.next().unwrap(), 0))
-                .to_opaque();
+        let mut root: OpaqueNodePtr<Box<[u8]>, usize, 16> = NodePtr::allocate_node_ptr(
+            LeafNode::with_no_siblings(keys.next().unwrap(), 0),
+            &Global,
+        )
+        .to_opaque();
 
         for (idx, key) in keys.enumerate() {
             root = unsafe { insert_unchecked(root, key, idx + 1).unwrap().new_root };
@@ -145,6 +151,6 @@ mod tests {
         );
         assert_eq!(max_leaf.key_ref().as_ref(), &[u8::MAX]);
 
-        unsafe { deallocate_tree(root) }
+        unsafe { deallocate_tree(root, &Global) }
     }
 }

--- a/src/raw/representation/inner_node_256.rs
+++ b/src/raw/representation/inner_node_256.rs
@@ -307,7 +307,7 @@ pub struct Node256Iter<'a, K, V, const PREFIX_LEN: usize> {
 }
 
 #[cfg(not(feature = "nightly"))]
-impl<'a, K, V, const PREFIX_LEN: usize> Iterator for Node256Iter<'a, K, V, PREFIX_LEN> {
+impl<K, V, const PREFIX_LEN: usize> Iterator for Node256Iter<'_, K, V, PREFIX_LEN> {
     type Item = (u8, OpaqueNodePtr<K, V, PREFIX_LEN>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -322,7 +322,7 @@ impl<'a, K, V, const PREFIX_LEN: usize> Iterator for Node256Iter<'a, K, V, PREFI
 }
 
 #[cfg(not(feature = "nightly"))]
-impl<'a, K, V, const PREFIX_LEN: usize> DoubleEndedIterator for Node256Iter<'a, K, V, PREFIX_LEN> {
+impl<K, V, const PREFIX_LEN: usize> DoubleEndedIterator for Node256Iter<'_, K, V, PREFIX_LEN> {
     fn next_back(&mut self) -> Option<Self::Item> {
         while let Some((key, node)) = self.it.next_back() {
             match node {
@@ -335,7 +335,7 @@ impl<'a, K, V, const PREFIX_LEN: usize> DoubleEndedIterator for Node256Iter<'a, 
 }
 
 #[cfg(not(feature = "nightly"))]
-impl<'a, K, V, const PREFIX_LEN: usize> FusedIterator for Node256Iter<'a, K, V, PREFIX_LEN> {}
+impl<K, V, const PREFIX_LEN: usize> FusedIterator for Node256Iter<'_, K, V, PREFIX_LEN> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/raw/representation/inner_node_48.rs
+++ b/src/raw/representation/inner_node_48.rs
@@ -565,7 +565,7 @@ pub struct Node48Iter<'a, K, V, const PREFIX_LEN: usize> {
 }
 
 #[cfg(not(feature = "nightly"))]
-impl<'a, K, V, const PREFIX_LEN: usize> Iterator for Node48Iter<'a, K, V, PREFIX_LEN> {
+impl<K, V, const PREFIX_LEN: usize> Iterator for Node48Iter<'_, K, V, PREFIX_LEN> {
     type Item = (u8, OpaqueNodePtr<K, V, PREFIX_LEN>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -584,7 +584,7 @@ impl<'a, K, V, const PREFIX_LEN: usize> Iterator for Node48Iter<'a, K, V, PREFIX
 }
 
 #[cfg(not(feature = "nightly"))]
-impl<'a, K, V, const PREFIX_LEN: usize> DoubleEndedIterator for Node48Iter<'a, K, V, PREFIX_LEN> {
+impl<K, V, const PREFIX_LEN: usize> DoubleEndedIterator for Node48Iter<'_, K, V, PREFIX_LEN> {
     fn next_back(&mut self) -> Option<Self::Item> {
         while let Some((key, idx)) = self.it.next_back() {
             if idx.is_empty() {
@@ -601,7 +601,7 @@ impl<'a, K, V, const PREFIX_LEN: usize> DoubleEndedIterator for Node48Iter<'a, K
 }
 
 #[cfg(not(feature = "nightly"))]
-impl<'a, K, V, const PREFIX_LEN: usize> FusedIterator for Node48Iter<'a, K, V, PREFIX_LEN> {}
+impl<K, V, const PREFIX_LEN: usize> FusedIterator for Node48Iter<'_, K, V, PREFIX_LEN> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/raw/visitor/pretty_printer.rs
+++ b/src/raw/visitor/pretty_printer.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alloc::Allocator,
     raw::{InnerNode, NodeType, OpaqueNodePtr},
     visitor::{Visitable, Visitor},
     AsBytes, NoPrefixesBytes, OrderedBytes, TreeMap,
@@ -30,9 +31,9 @@ pub struct DotPrinter<O: Write> {
 
 impl<O: Write> DotPrinter<O> {
     /// Write the dot-format of the given tree to the given output.
-    pub fn print<K, V, const PREFIX_LEN: usize>(
+    pub fn print<K, V, const PREFIX_LEN: usize, A: Allocator>(
         output: O,
-        tree: &TreeMap<K, V, PREFIX_LEN>,
+        tree: &TreeMap<K, V, PREFIX_LEN, A>,
         settings: DotPrinterSettings,
     ) -> Option<io::Result<()>>
     where
@@ -270,7 +271,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{raw::deallocate_tree, AsBytes};
+    use crate::{alloc::Global, raw::deallocate_tree, AsBytes};
 
     use super::*;
 
@@ -366,6 +367,6 @@ n0:c3 -> n16:h0
 "
         );
 
-        unsafe { deallocate_tree(root) };
+        unsafe { deallocate_tree(root, &Global) };
     }
 }

--- a/src/raw/visitor/tree_stats.rs
+++ b/src/raw/visitor/tree_stats.rs
@@ -1,6 +1,7 @@
 use std::ops::Add;
 
 use crate::{
+    alloc::Allocator,
     raw::{InnerNode, InnerNode16, InnerNode256, InnerNode4, InnerNode48, LeafNode},
     visitor::{Visitable, Visitor},
     AsBytes, TreeMap,
@@ -16,8 +17,8 @@ pub struct TreeStatsCollector {
 impl TreeStatsCollector {
     /// Run the tree stats collection on the given root node, then return the
     /// accumulated stats.
-    pub fn collect<K: AsBytes, V, const PREFIX_LEN: usize>(
-        tree: &TreeMap<K, V, PREFIX_LEN>,
+    pub fn collect<K: AsBytes, V, A: Allocator, const PREFIX_LEN: usize>(
+        tree: &TreeMap<K, V, PREFIX_LEN, A>,
     ) -> Option<TreeStats> {
         if let Some(state) = &tree.state {
             let mut collector = TreeStatsCollector {

--- a/src/rust_nightly_apis.rs
+++ b/src/rust_nightly_apis.rs
@@ -299,7 +299,7 @@ pub(crate) mod ptr {
     #[inline]
     #[cfg(not(feature = "nightly"))]
     pub fn mut_with_addr<T>(ptr: *mut T, addr: usize) -> *mut T {
-        let self_addr = ptr.addr() as isize;
+        let self_addr = mut_addr(ptr) as isize;
         let dest_addr = addr as isize;
         let offset = dest_addr.wrapping_sub(self_addr);
 

--- a/src/rust_nightly_apis.rs
+++ b/src/rust_nightly_apis.rs
@@ -295,6 +295,24 @@ pub(crate) mod ptr {
         ptr.addr()
     }
 
+    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+    #[inline]
+    #[cfg(not(feature = "nightly"))]
+    pub fn mut_with_addr<T>(ptr: *mut T, addr: usize) -> *mut T {
+        let self_addr = ptr.addr() as isize;
+        let dest_addr = addr as isize;
+        let offset = dest_addr.wrapping_sub(self_addr);
+
+        ptr.wrapping_byte_offset(offset)
+    }
+
+    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+    #[inline]
+    #[cfg(feature = "nightly")]
+    pub fn mut_with_addr<T>(ptr: *mut T, addr: usize) -> *mut T {
+        ptr.with_addr(addr)
+    }
+
     #[cfg(test)]
     #[inline]
     #[cfg(not(feature = "nightly"))]
@@ -302,7 +320,7 @@ pub(crate) mod ptr {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler
         // intrinsic. SAFETY: Pointer-to-integer transmutes are valid (if you
         // are okay with losing the provenance).
-        unsafe { std::mem::transmute(ptr.cast::<()>()) }
+        ptr.cast::<()>() as usize
     }
 
     #[cfg(test)]
@@ -310,6 +328,34 @@ pub(crate) mod ptr {
     #[cfg(feature = "nightly")]
     pub fn const_addr<T>(ptr: *const T) -> usize {
         ptr.addr()
+    }
+
+    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+    #[inline]
+    #[cfg(not(feature = "nightly"))]
+    pub fn nonnull_addr<T>(ptr: NonNull<T>) -> NonZeroUsize {
+        unsafe { NonZeroUsize::new_unchecked(mut_addr(ptr.as_ptr())) }
+    }
+
+    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+    #[inline]
+    #[cfg(feature = "nightly")]
+    pub fn nonnull_addr<T>(ptr: NonNull<T>) -> NonZeroUsize {
+        ptr.addr()
+    }
+
+    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+    #[inline]
+    #[cfg(not(feature = "nightly"))]
+    pub fn nonnull_with_addr<T>(ptr: NonNull<T>, addr: NonZeroUsize) -> NonNull<T> {
+        unsafe { NonNull::new_unchecked(mut_with_addr(ptr.as_ptr(), addr.get())) }
+    }
+
+    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
+    #[inline]
+    #[cfg(feature = "nightly")]
+    pub fn nonnull_with_addr<T>(ptr: NonNull<T>, addr: NonZeroUsize) -> NonNull<T> {
+        ptr.with_addr(addr)
     }
 
     #[inline]
@@ -321,15 +367,18 @@ pub(crate) mod ptr {
         let ptr = ptr.as_ptr();
         let old_addr = mut_addr(ptr);
         let new_addr = f(unsafe {
-            // SAFETY: TODO
+            // SAFETY: `ptr` was a `NonNull` pointer, the address was required to be
+            // non-zero.
             NonZeroUsize::new_unchecked(old_addr)
         });
-        let offset = new_addr.get().wrapping_sub(old_addr);
 
+        let offset = new_addr.get().wrapping_sub(old_addr);
         // This is the canonical desugaring of this operation
         let new_ptr = ptr.wrapping_byte_offset(offset as isize);
 
-        // SAFETY: TODO
+        // SAFETY: The 2 lines of code above are just changing the address of the
+        // pointer, while trying to retain the same provenance. Since the `new_addr`
+        // returned from `f` is non-zero, then the `new_ptr` must be non-null.
         unsafe { NonNull::new_unchecked(new_ptr) }
     }
 

--- a/src/tagged_pointer.rs
+++ b/src/tagged_pointer.rs
@@ -119,7 +119,12 @@ impl<P, const MIN_BITS: u32> TaggedPointer<P, MIN_BITS> {
     #[inline]
     pub fn to_ptr(self) -> NonNull<P> {
         ptr::nonnull_map_addr(self.0, |ptr_addr|
-            // SAFETY: TODO
+            // SAFETY:
+            //  1. The `new` function requires that the pointer passed is not null
+            //  2. The `new_unchecked` function requires that the pointer is aligned such 
+            //     that the bottom NUM_BITS are all zero.
+            // This means that the rest of the bits must be non-zero for the original
+            // non-null condition to hold.
             unsafe { NonZeroUsize::new_unchecked(ptr_addr.get() & Self::POINTER_MASK) })
     }
 

--- a/src/tests_common.rs
+++ b/src/tests_common.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashSet, iter};
 
 use crate::{
+    alloc::Global,
     raw::{InsertPrefixError, InsertResult, OpaqueNodePtr},
     AsBytes, TreeMap,
 };
@@ -336,7 +337,7 @@ where
     use crate::raw::search_for_insert_point;
 
     let insert_point = unsafe { search_for_insert_point(root, key.as_bytes())? };
-    Ok(unsafe { insert_point.apply(key, value) })
+    Ok(unsafe { insert_point.apply(key, value, &Global) })
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
**Description**
 - Modify the TreeMap interface so that it exposes a new generic parameter for the allocator, defaulting to the Rust global allocator.
 - Modify the internal tree operations to use the allocator stored in the tree for insert/delete/clone/dealloc operations
 - Add a new feature flag and optional dependency to consume the `Allocator` trait on the stable toolchain, also integrate with the `nightly` feature flag + toolchain to use that trait.
 - Also fix a bunch of clippy lints that are coming in on the latest nightly toolchains
   - Converting explicit lifetimes to `'_`

Note: The current OOM behavior is to panic. I may change this in the future to support an explicit `Err(...)`, but not to start at least.

**Motivation**
I think custom allocators are a very useful feature for making the the library more flexible and useful in `no_std` environments, or other non-standard scenarios. I was even able to experiment with using `bumpalo` as the custom allocator, which I think is neat.

**Testing Done**
I added some unit tests which create various custom allocators and use those to create/update/query/delete from `TreeMap`.