### PR TITLE
Implement extract_if iterator and associated map methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+ - Added `TreeMap::{extract_if, retain, split_off}` methods.
  - Add an optional feature to allow custom allocator support for use with collections. If the `nightly` feature flag is enabled and the `nightly` toolchain is used, then any type which implements `std::alloc::Allocator` can be used as the custom allocator. If the `allocator-api2` feature flag is enabled, then any type which implements `allocator_api2::alloc::Allocator` can be used as the custom allocator.
     - The `nightly` feature flag takes precedence over the `allocator-api2` feature flag.
     - The `allocator-api2` feature flag works on stable, while the `nightly` feature flag does not.
 
 ### Changed
 
+ - `DotPrinter` now allows directly providing the `fmt` function for key/value display, instead of wrapping existing types.
  - Update MSRV to 1.82.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ This will run the fuzzer for a total of 3600 seconds (1 hour), using 8 jobs (hal
 
 ### Coverage
 
-To generate coverage reports from fuzzing corpus:
+To generate coverage data from fuzzing corpus:
+
+```bash
+cargo +nightly fuzz coverage tree_map_api
+```
+
+To generate an HTML report of line-level coverage:
 
 ```bash
 TARGET_TRIPLE="$(rustc --print host-tuple)"

--- a/benches/iai_callgrind.rs
+++ b/benches/iai_callgrind.rs
@@ -232,16 +232,16 @@ fn bench_extract_if<K: AsBytes, V, const PREFIX_LEN: usize>(
     mode: &str,
 ) {
     let extracted: Vec<_> = match mode {
-        "all" => tree.extract_if(|_, _| true).collect(),
+        "all" => tree.extract_if(.., |_, _| true).collect(),
         "half" => {
             let mut i = 0;
-            tree.extract_if(|_, _| {
+            tree.extract_if(.., |_, _| {
                 i += 1;
                 i % 2 == 0
             })
             .collect()
         },
-        "none" => tree.extract_if(|_, _| false).collect(),
+        "none" => tree.extract_if(.., |_, _| false).collect(),
         _ => unreachable!(),
     };
     std::hint::black_box(extracted);

--- a/src/collections/map/iterators.rs
+++ b/src/collections/map/iterators.rs
@@ -12,3 +12,6 @@ pub use fuzzy::*;
 
 mod range;
 pub use range::*;
+
+mod extract_if;
+pub use extract_if::*;

--- a/src/collections/map/iterators/extract_if.rs
+++ b/src/collections/map/iterators/extract_if.rs
@@ -1,0 +1,547 @@
+use crate::{
+    alloc::Allocator,
+    collections::map::TreeMap,
+    raw::{
+        ConcreteNodePtr, DeleteParentNodeChange, DeletePoint, DeleteResult, InnerNode, LeafNode,
+        NodePtr, OpaqueNodePtr, TreePath,
+    },
+};
+use std::{fmt, iter::FusedIterator};
+
+enum DfsFrame<K, V, const PREFIX_LEN: usize> {
+    /// This variant represents a tree node and optionally the key byte which
+    /// was used to select this specific node from its parent.
+    Node((Option<u8>, OpaqueNodePtr<K, V, PREFIX_LEN>)),
+    /// This variant is used to cleanup the `ancestor` path.
+    PopAncestor,
+}
+
+impl<K, V, const PREFIX_LEN: usize> fmt::Debug for DfsFrame<K, V, PREFIX_LEN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Node(arg0) => f.debug_tuple("Node").field(arg0).finish(),
+            Self::PopAncestor => write!(f, "PopAncestor"),
+        }
+    }
+}
+
+struct ExtractIfState<K, V, const PREFIX_LEN: usize> {
+    /// This stack tracks ancestry of the `current_leaf` all the way to the root
+    /// node.
+    ancestors: Vec<OpaqueNodePtr<K, V, PREFIX_LEN>>,
+    /// This stack tracks the "parent key byte" to the root node.
+    ///
+    /// The length of this stack will always be one less than the length of
+    /// `nodes`, since the root node has no "parent key byte".
+    key_bytes: Vec<u8>,
+    /// This stack tracks the DFS exploration actions, including when ancestors
+    /// should be popped.
+    dfs_stack: Vec<DfsFrame<K, V, PREFIX_LEN>>,
+}
+
+impl<K, V, const PREFIX_LEN: usize> fmt::Debug for ExtractIfState<K, V, PREFIX_LEN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtractIfState")
+            .field("ancestors", &self.ancestors)
+            .field("key_bytes", &self.key_bytes)
+            .field("dfs_stack", &self.dfs_stack)
+            .finish()
+    }
+}
+
+impl<K, V, const PREFIX_LEN: usize> ExtractIfState<K, V, PREFIX_LEN> {
+    fn new(root: Option<OpaqueNodePtr<K, V, PREFIX_LEN>>) -> Self {
+        let mut dfs_stack = vec![];
+        if let Some(root) = root {
+            dfs_stack.push(DfsFrame::Node((None, root)))
+        }
+        Self {
+            ancestors: vec![],
+            key_bytes: vec![],
+            dfs_stack,
+        }
+    }
+
+    fn pop(&mut self) -> Option<(Option<u8>, OpaqueNodePtr<K, V, PREFIX_LEN>)> {
+        loop {
+            match self.dfs_stack.pop()? {
+                DfsFrame::Node(node) => {
+                    return Some(node);
+                },
+                DfsFrame::PopAncestor => self.pop_ancestor(),
+            }
+        }
+    }
+
+    fn pop_ancestor(&mut self) {
+        let _ = self
+            .ancestors
+            .pop()
+            .expect("there should not be a mismatched number of ancestors and pop frames");
+        let _ = self.key_bytes.pop();
+    }
+
+    fn current_parent_key_byte(&self) -> Option<u8> {
+        self.key_bytes.last().copied()
+    }
+
+    fn current_tree_path(&self, child_key_byte: Option<u8>) -> TreePath<K, V, PREFIX_LEN> {
+        let Some(parent) = self.ancestors.last().copied() else {
+            return TreePath::Root;
+        };
+
+        let child_key_byte =
+            child_key_byte.expect("child key byte should be present if there is a parent node");
+
+        let grandparent = self
+            .ancestors
+            .len()
+            .checked_sub(2)
+            .and_then(|idx| self.ancestors.get(idx))
+            .copied();
+        let parent_key_byte = self.current_parent_key_byte();
+
+        let Some((grandparent, parent_key_byte)) = grandparent.zip(parent_key_byte) else {
+            return TreePath::ChildOfRoot {
+                parent,
+                child_key_byte,
+            };
+        };
+
+        TreePath::Normal {
+            grandparent,
+            parent_key_byte,
+            parent,
+            child_key_byte,
+        }
+    }
+
+    /// This function will update any pointers in the ancestor path that are now
+    /// outdated because of the delete (parent pointers).
+    ///
+    /// If it returns `true`, then the parent node was compressed out of the
+    /// tree and the DFS stack needs to be updated.
+    fn fixup_after_delete(&mut self, delete_result: &DeleteResult<K, V, PREFIX_LEN>) {
+        let removed_ancestor = match delete_result.parent_node_change {
+            Some(DeleteParentNodeChange::NoChange) => {
+                // No change in the parent node means that the DFS doesn't need to be fixed
+                false
+            },
+            Some(DeleteParentNodeChange::Shrunk { new_parent_node }) => {
+                // Shrunk parent node means that we can just in-place swap it out, without
+                // changing the length of the ancestor path
+
+                let parent = self
+                    .ancestors
+                    .last_mut()
+                    .expect("there should be a parent if it was shrunk");
+                *parent = new_parent_node;
+
+                // DFS doesn't need any fixup if the number of ancestors remains the same
+                false
+            },
+            Some(DeleteParentNodeChange::SingletonCompressed { child_node_ptr }) => {
+                // If we compressed an inner node, that means that there was a single remaining
+                // child in the old parent node that was pulled up to be a child of the
+                // grandparent node OR the single remaining node was pulled up to be the new
+                // root.
+                //
+                // We need to fixup that node's entry in the DFS stack so that
+                // its associated key byte is now the old parent's key byte so that we don't
+                // accidentally delete the wrong node later on.
+                //
+                // The `SingletonCompress` fixup cases has two(?) variants:
+                //   1. The single remaining child in the node was already visited by the
+                //      `ExtractIf` iterator, in which case we don't need to update it.
+                //   2. The single remaining child in the node has not yet been visited, in
+                //      which case we need to update it.
+
+                if let Some(parent_key_byte) = self.current_parent_key_byte() {
+                    let child_ptr_frame = self
+                        .dfs_stack
+                        .iter_mut()
+                        .filter_map(|frame| match frame {
+                            DfsFrame::Node(node) => Some(node),
+                            DfsFrame::PopAncestor => None,
+                        })
+                        .rfind(|(_, node)| *node == child_node_ptr);
+
+                    // This is the code for the case #2. For case #1, we simply ignore it because
+                    // the iterator has already visited that node.
+                    if let Some(child_ptr_frame) = child_ptr_frame {
+                        child_ptr_frame.0 = Some(parent_key_byte);
+                    }
+                }
+
+                debug_assert!(
+                    !self.ancestors.is_empty(),
+                    "there should be a parent node on the stack before removal"
+                );
+                self.pop_ancestor();
+
+                // Since we're removing a key byte and parent node, we should fixup the DFS
+                // stack as well and remove the most recently occurring `PopAncestor` frame.
+                true
+            },
+            None => {
+                // `None` indicates that the previous root node was deleted and the tree is now
+                // empty
+                self.key_bytes.clear();
+                let had_parent_nodes = !self.ancestors.is_empty();
+                self.ancestors.clear();
+                had_parent_nodes
+            },
+        };
+
+        if removed_ancestor {
+            // Need to remove the top-most `PopAncestor` frame so that the number of
+            // ancestors and the number of ancestor frames don't go out of sync
+            let (top_pop_idx, _) = self
+                .dfs_stack
+                .iter()
+                .enumerate()
+                .rfind(|(_, f)| matches!(f, DfsFrame::PopAncestor))
+                .expect("there should be a `PopAncestor` frame in the stack");
+
+            let _ = self.dfs_stack.remove(top_pop_idx);
+        }
+    }
+
+    /// Add a new ancestor to the path and their children to the DFS stack.
+    ///
+    /// If the new ancestor is the tree root, the `key_byte` argument should
+    /// be `None`. Otherwise, it must be `Some(_)`.
+    ///
+    /// # Safety
+    ///
+    /// The inner node must not be concurrently mutated and there must not be an
+    /// existing mutable reference to the inner node.
+    unsafe fn extend_back<N>(&mut self, inner_ptr: NodePtr<PREFIX_LEN, N>, key_byte: Option<u8>)
+    where
+        N: InnerNode<PREFIX_LEN, Key = K, Value = V>,
+    {
+        // !self.key_bytes.is_empty() -> key_byte.is_some()
+        // key_byte.is_none() -> self.key_bytes.is_empty()
+        // A -> B === !A || B
+        debug_assert!(self.key_bytes.is_empty() || key_byte.is_some());
+
+        // SAFETY: Covered by function caller requirements. Additionally, the created
+        // reference is bounded to this function call.
+        let inner = unsafe { inner_ptr.as_ref() };
+
+        self.dfs_stack.push(DfsFrame::PopAncestor);
+        // Extend reversed so that the first child is on top of the DFS stack
+        self.dfs_stack.extend(
+            inner
+                .iter()
+                .rev()
+                .map(|(key_byte, node)| DfsFrame::Node((Some(key_byte), node))),
+        );
+
+        self.ancestors.push(inner_ptr.to_opaque());
+        if let Some(key_byte) = key_byte {
+            self.key_bytes.push(key_byte);
+        }
+    }
+}
+
+/// An iterator which uses a closure to determine if an element should be
+/// removed.
+///
+/// This struct is created by the [`extract_if`][TreeMap::extract_if] method
+/// on [`TreeMap`]. See its documentation for more.
+#[derive(Debug)]
+pub struct ExtractIf<'a, K, V, F, const PREFIX_LEN: usize, A: Allocator> {
+    map: &'a mut TreeMap<K, V, PREFIX_LEN, A>,
+    pred: F,
+    // The stack tracks the current ancestor chain
+    state: ExtractIfState<K, V, PREFIX_LEN>,
+    size: usize,
+    // This field tracks the next leaf to be returned by the iterator.
+    //
+    // If `None`, then the iterator is exhausted.
+    current_leaf: Option<(Option<u8>, NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>)>,
+}
+
+impl<'a, K, V, F, const PREFIX_LEN: usize, A> ExtractIf<'a, K, V, F, PREFIX_LEN, A>
+where
+    F: FnMut(&K, &mut V) -> bool,
+    A: Allocator,
+{
+    pub(crate) fn new(map: &'a mut TreeMap<K, V, PREFIX_LEN, A>, pred: F) -> Self {
+        let size = map.len();
+        let state = ExtractIfState::new(map.state.as_ref().map(|s| s.root));
+
+        let mut iter = Self {
+            map,
+            pred,
+            state,
+            current_leaf: None,
+            size,
+        };
+
+        iter.current_leaf = iter.find_next_leaf();
+
+        iter
+    }
+
+    #[inline]
+    fn extend_back(
+        &mut self,
+        inner_node: NodePtr<PREFIX_LEN, impl InnerNode<PREFIX_LEN, Key = K, Value = V>>,
+        key_byte: Option<u8>,
+    ) {
+        // SAFETY: We have a mutable reference to the overall tree, so there should be
+        // no concurrent modification or any other existing mutable references to the
+        // inner node.
+        unsafe { self.state.extend_back(inner_node, key_byte) };
+    }
+
+    fn find_next_leaf(
+        &mut self,
+    ) -> Option<(Option<u8>, NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>)> {
+        while let Some((key_byte, node)) = self.state.pop() {
+            match node.to_node_ptr() {
+                ConcreteNodePtr::Node4(inner_node) => self.extend_back(inner_node, key_byte),
+                ConcreteNodePtr::Node16(inner_node) => self.extend_back(inner_node, key_byte),
+                ConcreteNodePtr::Node48(inner_node) => self.extend_back(inner_node, key_byte),
+                ConcreteNodePtr::Node256(inner_node) => self.extend_back(inner_node, key_byte),
+                ConcreteNodePtr::LeafNode(leaf_node) => {
+                    return Some((key_byte, leaf_node));
+                },
+            }
+        }
+
+        None
+    }
+}
+
+impl<'a, K, V, F, const PREFIX_LEN: usize, A> Iterator for ExtractIf<'a, K, V, F, PREFIX_LEN, A>
+where
+    F: FnMut(&K, &mut V) -> bool,
+    A: Allocator,
+{
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((key_byte, leaf_node_ptr)) = self.current_leaf.take() {
+            self.size -= 1;
+
+            let should_remove = {
+                // SAFETY: The leaf node lifetime is scoped to this block and we don't have any
+                // other reference to this leaf. Also, we hold a mutable reference to the
+                // overall tree, so no concurrent modification or access to the tree is
+                // possible.
+                let leaf_node = unsafe { leaf_node_ptr.as_mut() };
+                let (k, v) = leaf_node.entry_mut();
+                (self.pred)(k, v)
+            };
+
+            if !should_remove {
+                self.current_leaf = self.find_next_leaf();
+                continue;
+            }
+
+            let delete_point = DeletePoint {
+                path: self.state.current_tree_path(key_byte),
+                leaf_node_ptr,
+            };
+
+            // The danger of this method is that during application, the parent node may be
+            // deallocated and reallocated at a different size. We need to make sure to
+            // fixup the ancestor chain entry and cleanup the DFS stack.
+            //
+            // SAFETY: The `ExtractIfState` contains a bunch of pointers into the tree, some
+            // of which are going to be invalidated by the delete. The `fixup_after_delete`
+            // method should fix all the invalidated pointers.
+            let delete_result = unsafe { self.map.apply_delete_point(delete_point) };
+
+            self.state.fixup_after_delete(&delete_result);
+
+            self.current_leaf = self.find_next_leaf();
+
+            return Some(delete_result.deleted_leaf.into_entry());
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.size))
+    }
+}
+
+impl<K, V, F, const PREFIX_LEN: usize, A> FusedIterator for ExtractIf<'_, K, V, F, PREFIX_LEN, A>
+where
+    F: FnMut(&K, &mut V) -> bool,
+    A: Allocator,
+{
+}
+
+// TODO: Make it DoubleEndedIterator using VecDeque
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        tests_common::{generate_key_fixed_length, swap},
+        TreeMap,
+    };
+
+    #[test]
+    fn extract_if_simple() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(|_k, v| *v % 2 == 0).collect();
+
+        assert_eq!(drained.len(), 5);
+        assert_eq!(map.len(), 5);
+        assert_eq!(drained, vec![(0, 0), (2, 2), (4, 4), (6, 6), (8, 8)]);
+        assert_eq!(
+            map.into_iter().collect::<Vec<_>>(),
+            vec![(1, 1), (3, 3), (5, 5), (7, 7), (9, 9)]
+        );
+    }
+
+    #[test]
+    fn extract_if_all() {
+        let first_width = if cfg!(miri) { 15 } else { u8::MAX };
+        let mut map: TreeMap<_, usize> = generate_key_fixed_length([first_width, 1])
+            .enumerate()
+            .map(swap)
+            .collect();
+
+        let drained: Vec<_> = map.extract_if(|_, _| true).collect();
+        let expected_len = if cfg!(miri) { 32 } else { 512 };
+        assert_eq!(drained.len(), expected_len);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn extract_if_none() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(|_, _| false).collect();
+
+        assert!(drained.is_empty());
+        assert_eq!(map.len(), 10);
+    }
+
+    #[test]
+    fn extract_if_mutate() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map
+            .extract_if(|_k, v| {
+                if *v % 2 == 0 {
+                    true
+                } else {
+                    *v *= 2;
+                    false
+                }
+            })
+            .collect();
+
+        assert_eq!(drained.len(), 5);
+        assert_eq!(map.len(), 5);
+        assert_eq!(
+            map.into_iter().collect::<Vec<_>>(),
+            vec![(1, 2), (3, 6), (5, 10), (7, 14), (9, 18)]
+        );
+    }
+
+    #[test]
+    fn extract_if_size_hint_none_removed() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let initial_len = map.len();
+        let mut iter = map.extract_if(|_k, _v| false); // Predicate removes none
+
+        assert_eq!(iter.size_hint(), (0, Some(10)));
+        // A single iterator step will empty it, since it doesn't remove any elements
+        assert!(iter.next().is_none());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(map.len(), initial_len);
+    }
+
+    #[test]
+    fn extract_if_size_hint_mixed_removed() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let initial_len = map.len();
+        let mut iter = map.extract_if(|k, _v| k % 2 == 0); // Predicate removes evens
+        let mut processed_count = 1;
+
+        for _ in 0..(initial_len / 2) {
+            assert!(iter.next().is_some());
+            assert_eq!(iter.size_hint(), (0, Some(initial_len - processed_count)));
+            processed_count += 2;
+        }
+        // This behavior seemed a bit odd to me at first, since I would expect that
+        // `Some(1)` means that there is one more element in the iterator. But it
+        // actually indicates that there is **at most** one more element in the
+        // iterator. And in this case it turns out there are no more elements in the
+        // iterator.
+        assert_eq!(iter.size_hint(), (0, Some(1)));
+        assert!(iter.next().is_none()); // clear out last odd value
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        // After the iterator is dropped, we can check the final map length
+        let expected_remaining = initial_len - (initial_len / 2); // 10 - 5 = 5
+        assert_eq!(map.len(), expected_remaining);
+    }
+
+    #[test]
+    fn tree_map_extract_if_interrupted() {
+        // Exactly the same as `retain`, on panic the iteration should stop.
+
+        let map: TreeMap<_, _> = generate_key_fixed_length([15, 3])
+            .enumerate()
+            .map(swap)
+            .collect();
+
+        assert_eq!(map.len(), 64);
+        let map = std::sync::Mutex::new(map);
+        let res = std::panic::catch_unwind(|| {
+            let mut map = map.lock().unwrap();
+            let _: Vec<_> = map
+                .extract_if(|_, v| if *v == 32 { panic!("stop") } else { true })
+                .collect();
+        });
+        assert!(res.is_err());
+        assert!(map.is_poisoned());
+        // We know in this case that the map should be fine after the panic
+        map.clear_poison();
+        let map = map.into_inner().unwrap();
+        assert!(map.into_values().eq(32..64));
+    }
+
+    #[test]
+    fn singleton_compress_previous_child_in_node() {
+        // The `SingletonCompress` fixup cases has two(?) variants:
+        //   1. The single remaining child in the node was already visited by the
+        //      `ExtractIf` iterator, in which case we don't need to update it.
+        //   2. The single remaining child in the node has not yet been visited, in
+        //      which case we need to update it.
+
+        let mut tree: TreeMap<_, _> = [
+            // root node
+            [1, 0],
+            [2, 0],
+            [3, 0],
+            [4, 0],
+            // parent node which will be singleton compressed
+            [1, 1],
+            [1, 2],
+            [1, 3],
+        ]
+        .into_iter()
+        .enumerate()
+        .map(swap)
+        .collect();
+
+        // Case 1: The first child in the parent node will be kept and singleton
+        // compressed
+        tree.clone()
+            .extract_if(|k, _| if k[0] == 1 { k[1] != 0 } else { false })
+            .for_each(drop);
+
+        // Case 2: The last child in the parent node will be kept and singleton
+        // compressed
+        tree.extract_if(|k, _| if k[0] == 1 { k[1] != 3 } else { false })
+            .for_each(drop);
+    }
+}

--- a/src/collections/map/iterators/extract_if.rs
+++ b/src/collections/map/iterators/extract_if.rs
@@ -1,249 +1,11 @@
 use crate::{
     alloc::Allocator,
     collections::map::TreeMap,
-    raw::{
-        ConcreteNodePtr, DeleteParentNodeChange, DeletePoint, DeleteResult, InnerNode, LeafNode,
-        NodePtr, OpaqueNodePtr, TreePath,
-    },
+    map::find_leaf_pointer_for_bound,
+    raw::{search_for_delete_point, LeafNode, NodePtr, RawIterator},
+    AsBytes,
 };
-use std::{fmt, iter::FusedIterator};
-
-enum DfsFrame<K, V, const PREFIX_LEN: usize> {
-    /// This variant represents a tree node and optionally the key byte which
-    /// was used to select this specific node from its parent.
-    Node((Option<u8>, OpaqueNodePtr<K, V, PREFIX_LEN>)),
-    /// This variant is used to cleanup the `ancestor` path.
-    PopAncestor,
-}
-
-impl<K, V, const PREFIX_LEN: usize> fmt::Debug for DfsFrame<K, V, PREFIX_LEN> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Node(arg0) => f.debug_tuple("Node").field(arg0).finish(),
-            Self::PopAncestor => write!(f, "PopAncestor"),
-        }
-    }
-}
-
-struct ExtractIfState<K, V, const PREFIX_LEN: usize> {
-    /// This stack tracks ancestry of the `current_leaf` all the way to the root
-    /// node.
-    ancestors: Vec<OpaqueNodePtr<K, V, PREFIX_LEN>>,
-    /// This stack tracks the "parent key byte" to the root node.
-    ///
-    /// The length of this stack will always be one less than the length of
-    /// `nodes`, since the root node has no "parent key byte".
-    key_bytes: Vec<u8>,
-    /// This stack tracks the DFS exploration actions, including when ancestors
-    /// should be popped.
-    dfs_stack: Vec<DfsFrame<K, V, PREFIX_LEN>>,
-}
-
-impl<K, V, const PREFIX_LEN: usize> fmt::Debug for ExtractIfState<K, V, PREFIX_LEN> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ExtractIfState")
-            .field("ancestors", &self.ancestors)
-            .field("key_bytes", &self.key_bytes)
-            .field("dfs_stack", &self.dfs_stack)
-            .finish()
-    }
-}
-
-impl<K, V, const PREFIX_LEN: usize> ExtractIfState<K, V, PREFIX_LEN> {
-    fn new(root: Option<OpaqueNodePtr<K, V, PREFIX_LEN>>) -> Self {
-        let mut dfs_stack = vec![];
-        if let Some(root) = root {
-            dfs_stack.push(DfsFrame::Node((None, root)))
-        }
-        Self {
-            ancestors: vec![],
-            key_bytes: vec![],
-            dfs_stack,
-        }
-    }
-
-    fn pop(&mut self) -> Option<(Option<u8>, OpaqueNodePtr<K, V, PREFIX_LEN>)> {
-        loop {
-            match self.dfs_stack.pop()? {
-                DfsFrame::Node(node) => {
-                    return Some(node);
-                },
-                DfsFrame::PopAncestor => self.pop_ancestor(),
-            }
-        }
-    }
-
-    fn pop_ancestor(&mut self) {
-        let _ = self
-            .ancestors
-            .pop()
-            .expect("there should not be a mismatched number of ancestors and pop frames");
-        let _ = self.key_bytes.pop();
-    }
-
-    fn current_parent_key_byte(&self) -> Option<u8> {
-        self.key_bytes.last().copied()
-    }
-
-    fn current_tree_path(&self, child_key_byte: Option<u8>) -> TreePath<K, V, PREFIX_LEN> {
-        let Some(parent) = self.ancestors.last().copied() else {
-            return TreePath::Root;
-        };
-
-        let child_key_byte =
-            child_key_byte.expect("child key byte should be present if there is a parent node");
-
-        let grandparent = self
-            .ancestors
-            .len()
-            .checked_sub(2)
-            .and_then(|idx| self.ancestors.get(idx))
-            .copied();
-        let parent_key_byte = self.current_parent_key_byte();
-
-        let Some((grandparent, parent_key_byte)) = grandparent.zip(parent_key_byte) else {
-            return TreePath::ChildOfRoot {
-                parent,
-                child_key_byte,
-            };
-        };
-
-        TreePath::Normal {
-            grandparent,
-            parent_key_byte,
-            parent,
-            child_key_byte,
-        }
-    }
-
-    /// This function will update any pointers in the ancestor path that are now
-    /// outdated because of the delete (parent pointers).
-    ///
-    /// If it returns `true`, then the parent node was compressed out of the
-    /// tree and the DFS stack needs to be updated.
-    fn fixup_after_delete(&mut self, delete_result: &DeleteResult<K, V, PREFIX_LEN>) {
-        let removed_ancestor = match delete_result.parent_node_change {
-            Some(DeleteParentNodeChange::NoChange) => {
-                // No change in the parent node means that the DFS doesn't need to be fixed
-                false
-            },
-            Some(DeleteParentNodeChange::Shrunk { new_parent_node }) => {
-                // Shrunk parent node means that we can just in-place swap it out, without
-                // changing the length of the ancestor path
-
-                let parent = self
-                    .ancestors
-                    .last_mut()
-                    .expect("there should be a parent if it was shrunk");
-                *parent = new_parent_node;
-
-                // DFS doesn't need any fixup if the number of ancestors remains the same
-                false
-            },
-            Some(DeleteParentNodeChange::SingletonCompressed { child_node_ptr }) => {
-                // If we compressed an inner node, that means that there was a single remaining
-                // child in the old parent node that was pulled up to be a child of the
-                // grandparent node OR the single remaining node was pulled up to be the new
-                // root.
-                //
-                // We need to fixup that node's entry in the DFS stack so that
-                // its associated key byte is now the old parent's key byte so that we don't
-                // accidentally delete the wrong node later on.
-                //
-                // The `SingletonCompress` fixup cases has two(?) variants:
-                //   1. The single remaining child in the node was already visited by the
-                //      `ExtractIf` iterator, in which case we don't need to update it.
-                //   2. The single remaining child in the node has not yet been visited, in
-                //      which case we need to update it.
-
-                if let Some(parent_key_byte) = self.current_parent_key_byte() {
-                    let child_ptr_frame = self
-                        .dfs_stack
-                        .iter_mut()
-                        .filter_map(|frame| match frame {
-                            DfsFrame::Node(node) => Some(node),
-                            DfsFrame::PopAncestor => None,
-                        })
-                        .rfind(|(_, node)| *node == child_node_ptr);
-
-                    // This is the code for the case #2. For case #1, we simply ignore it because
-                    // the iterator has already visited that node.
-                    if let Some(child_ptr_frame) = child_ptr_frame {
-                        child_ptr_frame.0 = Some(parent_key_byte);
-                    }
-                }
-
-                debug_assert!(
-                    !self.ancestors.is_empty(),
-                    "there should be a parent node on the stack before removal"
-                );
-                self.pop_ancestor();
-
-                // Since we're removing a key byte and parent node, we should fixup the DFS
-                // stack as well and remove the most recently occurring `PopAncestor` frame.
-                true
-            },
-            None => {
-                // `None` indicates that the previous root node was deleted and the tree is now
-                // empty
-                self.key_bytes.clear();
-                let had_parent_nodes = !self.ancestors.is_empty();
-                self.ancestors.clear();
-                had_parent_nodes
-            },
-        };
-
-        if removed_ancestor {
-            // Need to remove the top-most `PopAncestor` frame so that the number of
-            // ancestors and the number of ancestor frames don't go out of sync
-            let (top_pop_idx, _) = self
-                .dfs_stack
-                .iter()
-                .enumerate()
-                .rfind(|(_, f)| matches!(f, DfsFrame::PopAncestor))
-                .expect("there should be a `PopAncestor` frame in the stack");
-
-            let _ = self.dfs_stack.remove(top_pop_idx);
-        }
-    }
-
-    /// Add a new ancestor to the path and their children to the DFS stack.
-    ///
-    /// If the new ancestor is the tree root, the `key_byte` argument should
-    /// be `None`. Otherwise, it must be `Some(_)`.
-    ///
-    /// # Safety
-    ///
-    /// The inner node must not be concurrently mutated and there must not be an
-    /// existing mutable reference to the inner node.
-    unsafe fn extend_back<N>(&mut self, inner_ptr: NodePtr<PREFIX_LEN, N>, key_byte: Option<u8>)
-    where
-        N: InnerNode<PREFIX_LEN, Key = K, Value = V>,
-    {
-        // !self.key_bytes.is_empty() -> key_byte.is_some()
-        // key_byte.is_none() -> self.key_bytes.is_empty()
-        // A -> B === !A || B
-        debug_assert!(self.key_bytes.is_empty() || key_byte.is_some());
-
-        // SAFETY: Covered by function caller requirements. Additionally, the created
-        // reference is bounded to this function call.
-        let inner = unsafe { inner_ptr.as_ref() };
-
-        self.dfs_stack.push(DfsFrame::PopAncestor);
-        // Extend reversed so that the first child is on top of the DFS stack
-        self.dfs_stack.extend(
-            inner
-                .iter()
-                .rev()
-                .map(|(key_byte, node)| DfsFrame::Node((Some(key_byte), node))),
-        );
-
-        self.ancestors.push(inner_ptr.to_opaque());
-        if let Some(key_byte) = key_byte {
-            self.key_bytes.push(key_byte);
-        }
-    }
-}
+use std::{iter::FusedIterator, ops::Bound};
 
 /// An iterator which uses a closure to determine if an element should be
 /// removed.
@@ -252,132 +14,202 @@ impl<K, V, const PREFIX_LEN: usize> ExtractIfState<K, V, PREFIX_LEN> {
 /// on [`TreeMap`]. See its documentation for more.
 #[derive(Debug)]
 pub struct ExtractIf<'a, K, V, F, const PREFIX_LEN: usize, A: Allocator> {
-    map: &'a mut TreeMap<K, V, PREFIX_LEN, A>,
+    tree: &'a mut TreeMap<K, V, PREFIX_LEN, A>,
     pred: F,
-    // The stack tracks the current ancestor chain
-    state: ExtractIfState<K, V, PREFIX_LEN>,
-    size: usize,
-    // This field tracks the next leaf to be returned by the iterator.
-    //
-    // If `None`, then the iterator is exhausted.
-    current_leaf: Option<(Option<u8>, NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>)>,
+    inner: RawIterator<K, V, PREFIX_LEN>,
 }
 
 impl<'a, K, V, F, const PREFIX_LEN: usize, A> ExtractIf<'a, K, V, F, PREFIX_LEN, A>
 where
+    K: AsBytes,
     F: FnMut(&K, &mut V) -> bool,
     A: Allocator,
 {
-    pub(crate) fn new(map: &'a mut TreeMap<K, V, PREFIX_LEN, A>, pred: F) -> Self {
-        let size = map.len();
-        let state = ExtractIfState::new(map.state.as_ref().map(|s| s.root));
-
-        let mut iter = Self {
-            map,
-            pred,
-            state,
-            current_leaf: None,
-            size,
+    /// Create a new range iterator over the given tree, starting and ending
+    /// according to the given bounds.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `start_bound` is greater than `end_bound`.
+    pub(crate) fn new(
+        tree: &'a mut TreeMap<K, V, PREFIX_LEN, A>,
+        start_bound: Bound<&[u8]>,
+        end_bound: Bound<&[u8]>,
+        pred: F,
+    ) -> Self {
+        let Some(tree_state) = &tree.state else {
+            return Self {
+                tree,
+                pred,
+                inner: RawIterator::empty(),
+            };
         };
 
-        iter.current_leaf = iter.find_next_leaf();
-
-        iter
-    }
-
-    #[inline]
-    fn extend_back(
-        &mut self,
-        inner_node: NodePtr<PREFIX_LEN, impl InnerNode<PREFIX_LEN, Key = K, Value = V>>,
-        key_byte: Option<u8>,
-    ) {
-        // SAFETY: We have a mutable reference to the overall tree, so there should be
-        // no concurrent modification or any other existing mutable references to the
-        // inner node.
-        unsafe { self.state.extend_back(inner_node, key_byte) };
-    }
-
-    fn find_next_leaf(
-        &mut self,
-    ) -> Option<(Option<u8>, NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>)> {
-        while let Some((key_byte, node)) = self.state.pop() {
-            match node.to_node_ptr() {
-                ConcreteNodePtr::Node4(inner_node) => self.extend_back(inner_node, key_byte),
-                ConcreteNodePtr::Node16(inner_node) => self.extend_back(inner_node, key_byte),
-                ConcreteNodePtr::Node48(inner_node) => self.extend_back(inner_node, key_byte),
-                ConcreteNodePtr::Node256(inner_node) => self.extend_back(inner_node, key_byte),
-                ConcreteNodePtr::LeafNode(leaf_node) => {
-                    return Some((key_byte, leaf_node));
+        {
+            match (start_bound, end_bound) {
+                (Bound::Excluded(s), Bound::Excluded(e)) if s == e => {
+                    panic!("range start and end are equal and excluded: ({s:?})")
                 },
+                (
+                    Bound::Included(s) | Bound::Excluded(s),
+                    Bound::Included(e) | Bound::Excluded(e),
+                ) if s > e => {
+                    panic!("range start ({s:?}) is greater than range end ({e:?})")
+                },
+                _ => {},
             }
         }
 
-        None
+        // SAFETY: Since we have a (shared or mutable) reference to the original
+        // TreeMap, we know there will be no concurrent mutation
+        let possible_start = unsafe { find_leaf_pointer_for_bound(tree_state, start_bound, true) };
+        let Some(start) = possible_start else {
+            return Self {
+                tree,
+                pred,
+                inner: RawIterator::empty(),
+            };
+        };
+
+        // SAFETY: Since we have a (shared or mutable) reference to the original
+        // TreeMap, we know there will be no concurrent mutation
+        let possible_end = unsafe { find_leaf_pointer_for_bound(tree_state, end_bound, false) };
+        let Some(end) = possible_end else {
+            return Self {
+                tree,
+                pred,
+                inner: RawIterator::empty(),
+            };
+        };
+
+        // SAFETY: Since we have a (shared or mutable) reference to the original
+        // TreeMap, we know there will be no concurrent mutation. Also, the
+        // reference lifetimes created are bounded to this `unsafe` block, and
+        // don't overlap with any mutation.
+        unsafe {
+            let start_leaf_bytes = start.as_key_ref().as_bytes();
+            let end_leaf_bytes = end.as_key_ref().as_bytes();
+
+            if start_leaf_bytes > end_leaf_bytes {
+                // Resolved start leaf is not less than or equal to resolved end leaf for
+                // iteration order
+                return Self {
+                    tree,
+                    pred,
+                    inner: RawIterator::empty(),
+                };
+            }
+        }
+
+        Self {
+            tree,
+            pred,
+            // SAFETY: `start` is guaranteed to be less than or equal to `end` in the iteration
+            // order because of the check we do on the bytes of the resolved leaf pointers, just
+            // above this line
+            inner: unsafe { RawIterator::new(start, end) },
+        }
+    }
+
+    /// Test the given leaf node against the predicate and if it returns `true`
+    /// remove it from the tree.
+    fn test_and_remove_leaf(
+        &mut self,
+        leaf_ptr: NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>,
+    ) -> Option<LeafNode<K, V, PREFIX_LEN>> {
+        // SAFETY: The leaf node lifetime is scoped to this block and we don't have any
+        // other reference to this leaf. Also, we hold a mutable reference to the
+        // overall tree, so no concurrent modification or access to the tree is
+        // possible.
+        let leaf_node = unsafe { leaf_ptr.as_mut() };
+
+        let should_remove = {
+            let (k, v) = leaf_node.entry_mut();
+            (self.pred)(k, v)
+        };
+
+        if !should_remove {
+            return None;
+        }
+
+        let Some(state) = &self.tree.state else {
+            return None;
+        };
+
+        // SAFETY: Since we have a mutable reference to the `TreeMap`, we are guaranteed
+        // that there are no other references (mutable or immutable) to this same
+        // object. Meaning that our access to the root node is unique and there are no
+        // other accesses to any node in the tree.
+        let delete_point = unsafe {
+            search_for_delete_point(state.root, leaf_node.key_ref().as_bytes())
+                .expect("the delete point must be present in the tree if we're iterating over it")
+        };
+        // SAFETY: There are no outstanding pointers (besides leaf min/max which are
+        // already fixed by `apply_delete_pointer`).
+        let delete_result = unsafe { self.tree.apply_delete_point(delete_point) };
+
+        // The `RawIterator` state is already correct because we "pop" from that
+        // iterator already. The leaf linked list is updated by the `apply_delete_point`
+        // function.
+
+        Some(delete_result.deleted_leaf)
     }
 }
 
 impl<'a, K, V, F, const PREFIX_LEN: usize, A> Iterator for ExtractIf<'a, K, V, F, PREFIX_LEN, A>
 where
+    K: AsBytes,
     F: FnMut(&K, &mut V) -> bool,
     A: Allocator,
 {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((key_byte, leaf_node_ptr)) = self.current_leaf.take() {
-            self.size -= 1;
+        loop {
+            // SAFETY: This iterator has a reference (either shared or mutable) to the
+            // original `TreeMap` it is iterating over, preventing any other modification.
+            let leaf_ptr = unsafe { self.inner.next()? };
 
-            let should_remove = {
-                // SAFETY: The leaf node lifetime is scoped to this block and we don't have any
-                // other reference to this leaf. Also, we hold a mutable reference to the
-                // overall tree, so no concurrent modification or access to the tree is
-                // possible.
-                let leaf_node = unsafe { leaf_node_ptr.as_mut() };
-                let (k, v) = leaf_node.entry_mut();
-                (self.pred)(k, v)
-            };
-
-            if !should_remove {
-                self.current_leaf = self.find_next_leaf();
-                continue;
+            match self.test_and_remove_leaf(leaf_ptr) {
+                Some(leaf) => return Some(leaf.into_entry()),
+                None => {
+                    continue;
+                },
             }
-
-            let delete_point = DeletePoint {
-                path: self.state.current_tree_path(key_byte),
-                leaf_node_ptr,
-            };
-
-            // The danger of this method is that during application, the parent node may be
-            // deallocated and reallocated at a different size. We need to make sure to
-            // fixup the ancestor chain entry and cleanup the DFS stack.
-            //
-            // SAFETY: The `ExtractIfState` contains a bunch of pointers into the tree, some
-            // of which are going to be invalidated by the delete. The `fixup_after_delete`
-            // method should fix all the invalidated pointers.
-            let delete_result = unsafe { self.map.apply_delete_point(delete_point) };
-
-            self.state.fixup_after_delete(&delete_result);
-
-            self.current_leaf = self.find_next_leaf();
-
-            return Some(delete_result.deleted_leaf.into_entry());
         }
-        None
     }
+}
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.size))
+impl<'a, K, V, F, const PREFIX_LEN: usize, A> DoubleEndedIterator
+    for ExtractIf<'a, K, V, F, PREFIX_LEN, A>
+where
+    K: AsBytes,
+    F: FnMut(&K, &mut V) -> bool,
+    A: Allocator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            // SAFETY: This iterator has a reference (either shared or mutable) to the
+            // original `TreeMap` it is iterating over, preventing any other modification.
+            let leaf_ptr = unsafe { self.inner.next_back()? };
+
+            match self.test_and_remove_leaf(leaf_ptr) {
+                Some(leaf) => return Some(leaf.into_entry()),
+                None => {
+                    continue;
+                },
+            }
+        }
     }
 }
 
 impl<K, V, F, const PREFIX_LEN: usize, A> FusedIterator for ExtractIf<'_, K, V, F, PREFIX_LEN, A>
 where
+    K: AsBytes,
     F: FnMut(&K, &mut V) -> bool,
     A: Allocator,
 {
 }
-
-// TODO: Make it DoubleEndedIterator using VecDeque
 
 #[cfg(test)]
 mod tests {
@@ -389,7 +221,7 @@ mod tests {
     #[test]
     fn extract_if_simple() {
         let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
-        let drained: Vec<_> = map.extract_if(|_k, v| *v % 2 == 0).collect();
+        let drained: Vec<_> = map.extract_if(.., |_k, v| *v % 2 == 0).collect();
 
         assert_eq!(drained.len(), 5);
         assert_eq!(map.len(), 5);
@@ -408,7 +240,7 @@ mod tests {
             .map(swap)
             .collect();
 
-        let drained: Vec<_> = map.extract_if(|_, _| true).collect();
+        let drained: Vec<_> = map.extract_if(.., |_, _| true).collect();
         let expected_len = if cfg!(miri) { 32 } else { 512 };
         assert_eq!(drained.len(), expected_len);
         assert!(map.is_empty());
@@ -417,7 +249,7 @@ mod tests {
     #[test]
     fn extract_if_none() {
         let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
-        let drained: Vec<_> = map.extract_if(|_, _| false).collect();
+        let drained: Vec<_> = map.extract_if(.., |_, _| false).collect();
 
         assert!(drained.is_empty());
         assert_eq!(map.len(), 10);
@@ -427,7 +259,7 @@ mod tests {
     fn extract_if_mutate() {
         let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
         let drained: Vec<_> = map
-            .extract_if(|_k, v| {
+            .extract_if(.., |_k, v| {
                 if *v % 2 == 0 {
                     true
                 } else {
@@ -446,49 +278,10 @@ mod tests {
     }
 
     #[test]
-    fn extract_if_size_hint_none_removed() {
-        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
-        let initial_len = map.len();
-        let mut iter = map.extract_if(|_k, _v| false); // Predicate removes none
-
-        assert_eq!(iter.size_hint(), (0, Some(10)));
-        // A single iterator step will empty it, since it doesn't remove any elements
-        assert!(iter.next().is_none());
-        assert_eq!(iter.size_hint(), (0, Some(0)));
-        assert_eq!(map.len(), initial_len);
-    }
-
-    #[test]
-    fn extract_if_size_hint_mixed_removed() {
-        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
-        let initial_len = map.len();
-        let mut iter = map.extract_if(|k, _v| k % 2 == 0); // Predicate removes evens
-        let mut processed_count = 1;
-
-        for _ in 0..(initial_len / 2) {
-            assert!(iter.next().is_some());
-            assert_eq!(iter.size_hint(), (0, Some(initial_len - processed_count)));
-            processed_count += 2;
-        }
-        // This behavior seemed a bit odd to me at first, since I would expect that
-        // `Some(1)` means that there is one more element in the iterator. But it
-        // actually indicates that there is **at most** one more element in the
-        // iterator. And in this case it turns out there are no more elements in the
-        // iterator.
-        assert_eq!(iter.size_hint(), (0, Some(1)));
-        assert!(iter.next().is_none()); // clear out last odd value
-        assert_eq!(iter.size_hint(), (0, Some(0)));
-
-        // After the iterator is dropped, we can check the final map length
-        let expected_remaining = initial_len - (initial_len / 2); // 10 - 5 = 5
-        assert_eq!(map.len(), expected_remaining);
-    }
-
-    #[test]
     fn tree_map_extract_if_interrupted() {
         // Exactly the same as `retain`, on panic the iteration should stop.
 
-        let map: TreeMap<_, _> = generate_key_fixed_length([15, 3])
+        let map: TreeMap<[u8; 2], _> = generate_key_fixed_length([15, 3])
             .enumerate()
             .map(swap)
             .collect();
@@ -498,7 +291,7 @@ mod tests {
         let res = std::panic::catch_unwind(|| {
             let mut map = map.lock().unwrap();
             let _: Vec<_> = map
-                .extract_if(|_, v| if *v == 32 { panic!("stop") } else { true })
+                .extract_if(.., |_, v| if *v == 32 { panic!("stop") } else { true })
                 .collect();
         });
         assert!(res.is_err());
@@ -536,12 +329,222 @@ mod tests {
         // Case 1: The first child in the parent node will be kept and singleton
         // compressed
         tree.clone()
-            .extract_if(|k, _| if k[0] == 1 { k[1] != 0 } else { false })
+            .extract_if(.., |k, _| if k[0] == 1 { k[1] != 0 } else { false })
             .for_each(drop);
 
         // Case 2: The last child in the parent node will be kept and singleton
         // compressed
-        tree.extract_if(|k, _| if k[0] == 1 { k[1] != 3 } else { false })
+        tree.extract_if(.., |k, _| if k[0] == 1 { k[1] != 3 } else { false })
             .for_each(drop);
+    }
+
+    #[test]
+    fn double_ended_partial() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let mut iter = map.extract_if(.., |k, _v| *k % 2 == 0);
+
+        assert_eq!(iter.next(), Some((0, 0)));
+        assert_eq!(iter.next_back(), Some((8, 8)));
+        assert_eq!(iter.next(), Some((2, 2)));
+        assert_eq!(iter.next_back(), Some((6, 6)));
+        assert_eq!(iter.next(), Some((4, 4)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+
+        assert_eq!(map.len(), 5);
+        assert_eq!(
+            map.into_iter().collect::<Vec<_>>(),
+            vec![(1, 1), (3, 3), (5, 5), (7, 7), (9, 9)]
+        );
+    }
+
+    #[test]
+    fn double_ended_all() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let mut iter = map.extract_if(.., |_, _| true);
+
+        assert_eq!(iter.next(), Some((0, 0)));
+        assert_eq!(iter.next_back(), Some((9, 9)));
+        assert_eq!(iter.next(), Some((1, 1)));
+        assert_eq!(iter.next_back(), Some((8, 8)));
+
+        assert_eq!(map.len(), 6);
+        assert_eq!(
+            map.into_iter().collect::<Vec<_>>(),
+            vec![(2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7)]
+        );
+    }
+
+    #[test]
+    fn double_ended_none() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let mut iter = map.extract_if(.., |_, _| false);
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+
+        assert_eq!(map.len(), 10);
+    }
+
+    #[test]
+    fn range_inclusive() {
+        let mut map: TreeMap<i32, i32> = (0..20).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(2..=18, |k, _v| *k % 2 == 0).collect();
+
+        assert_eq!(drained.len(), 9);
+        assert_eq!(map.len(), 11);
+        assert_eq!(
+            drained,
+            vec![
+                (2, 2),
+                (4, 4),
+                (6, 6),
+                (8, 8),
+                (10, 10),
+                (12, 12),
+                (14, 14),
+                (16, 16),
+                (18, 18)
+            ]
+        );
+
+        let mut expected = (0..20).collect::<Vec<_>>();
+        expected.retain(|&i| !(2..=18).contains(&i) || i % 2 != 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn range_inclusive_rev() {
+        let mut map: TreeMap<i32, i32> = (0..20).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(2..=18, |k, _v| *k % 2 == 0).rev().collect();
+
+        assert_eq!(drained.len(), 9);
+        assert_eq!(map.len(), 11);
+        assert_eq!(
+            drained,
+            vec![
+                (18, 18),
+                (16, 16),
+                (14, 14),
+                (12, 12),
+                (10, 10),
+                (8, 8),
+                (6, 6),
+                (4, 4),
+                (2, 2)
+            ]
+        );
+
+        let mut expected = (0..20).collect::<Vec<_>>();
+        expected.retain(|&i| !(2..=18).contains(&i) || i % 2 != 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn range() {
+        let mut map: TreeMap<i32, i32> = (0..20).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(2..18, |k, _v| *k % 2 == 0).collect();
+
+        assert_eq!(drained.len(), 8);
+        assert_eq!(map.len(), 12);
+        assert_eq!(
+            drained,
+            vec![
+                (2, 2),
+                (4, 4),
+                (6, 6),
+                (8, 8),
+                (10, 10),
+                (12, 12),
+                (14, 14),
+                (16, 16)
+            ]
+        );
+
+        let mut expected = (0..20).collect::<Vec<_>>();
+        expected.retain(|&i| !(2..18).contains(&i) || i % 2 != 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn range_from() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(5.., |k, _v| *k % 2 != 0).collect();
+
+        assert_eq!(drained.len(), 3);
+        assert_eq!(map.len(), 7);
+        assert_eq!(drained, vec![(5, 5), (7, 7), (9, 9)]);
+
+        let mut expected = (0..10).collect::<Vec<_>>();
+        expected.retain(|&i| i < 5 || i % 2 == 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn range_to() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(..5, |k, _v| *k % 2 != 0).collect();
+
+        assert_eq!(drained.len(), 2);
+        assert_eq!(map.len(), 8);
+        assert_eq!(drained, vec![(1, 1), (3, 3)]);
+
+        let mut expected = (0..10).collect::<Vec<_>>();
+        expected.retain(|&i| i >= 5 || i % 2 == 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn range_to_inclusive() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(..=5, |k, _v| *k % 2 != 0).collect();
+
+        assert_eq!(drained.len(), 3);
+        assert_eq!(map.len(), 7);
+        assert_eq!(drained, vec![(1, 1), (3, 3), (5, 5)]);
+
+        let mut expected = (0..10).collect::<Vec<_>>();
+        expected.retain(|&i| i > 5 || i % 2 == 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn range_double_ended() {
+        let mut map: TreeMap<i32, i32> = (0..20).map(|i| (i, i)).collect();
+        let mut iter = map.extract_if(2..18, |k, _v| *k % 2 == 0);
+
+        assert_eq!(iter.next(), Some((2, 2)));
+        assert_eq!(iter.next_back(), Some((16, 16)));
+        assert_eq!(iter.next(), Some((4, 4)));
+        assert_eq!(iter.next_back(), Some((14, 14)));
+
+        assert_eq!(map.len(), 16);
+
+        let mut expected = (0..20).collect::<Vec<_>>();
+        expected.retain(|&i| !(2..18).contains(&i) || (i > 4 && i < 14) || i % 2 != 0);
+        let remaining: Vec<_> = map.into_iter().map(|(k, _)| k).collect();
+        assert_eq!(remaining, expected);
+    }
+
+    #[test]
+    fn empty_range() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let drained: Vec<_> = map.extract_if(5..5, |_, _| true).collect();
+        assert!(drained.is_empty());
+        assert_eq!(map.len(), 10);
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(clippy::reversed_empty_ranges)]
+    fn inverted_range() {
+        let mut map: TreeMap<i32, i32> = (0..10).map(|i| (i, i)).collect();
+        let _ = map.extract_if(5..2, |_, _| true);
     }
 }

--- a/src/collections/map/iterators/range.rs
+++ b/src/collections/map/iterators/range.rs
@@ -270,7 +270,7 @@ pub(crate) unsafe fn find_terminating_node<K: AsBytes, V, const PREFIX_LEN: usiz
 ///
 /// Callers must guarantee that there is no concurrent mutation of the given
 /// trie for the duration of this function.
-unsafe fn find_leaf_pointer_for_bound<K: AsBytes, V, const PREFIX_LEN: usize>(
+pub(crate) unsafe fn find_leaf_pointer_for_bound<K: AsBytes, V, const PREFIX_LEN: usize>(
     tree: &NonEmptyTree<K, V, PREFIX_LEN>,
     bound: Bound<&[u8]>,
     is_start: bool,

--- a/src/collections/map/iterators/range.rs
+++ b/src/collections/map/iterators/range.rs
@@ -259,6 +259,8 @@ pub(crate) unsafe fn find_terminating_node<K: AsBytes, V, const PREFIX_LEN: usiz
     }
 }
 
+type KeyByteAndChild<K, V, const PREFIX_LEN: usize> = Option<(u8, OpaqueNodePtr<K, V, PREFIX_LEN>)>;
+
 /// This function searches a trie for the smallest/largest leaf node that is
 /// greater/less than the given bound.
 ///
@@ -351,8 +353,7 @@ pub(crate) unsafe fn find_leaf_pointer_for_bound<K: AsBytes, V, const PREFIX_LEN
                             inner_ptr: NodePtr<PREFIX_LEN, N>,
                             child_bounds: (Bound<u8>, Bound<u8>),
                             is_start: bool,
-                        ) -> Option<(u8, OpaqueNodePtr<N::Key, N::Value, PREFIX_LEN>)>
-                        {
+                        ) -> KeyByteAndChild<N::Key, N::Value, PREFIX_LEN> {
                             // SAFETY: Covered by function safety doc
                             let inner = unsafe { inner_ptr.as_ref() };
                             let mut child_it = inner.range(child_bounds);

--- a/src/raw/iterator.rs
+++ b/src/raw/iterator.rs
@@ -84,12 +84,12 @@ impl<K, V, const PREFIX_LEN: usize> RawIterator<K, V, PREFIX_LEN> {
 
                 let next = *start;
 
-                // SAFETY: Covered by function safety doc
-                let start_leaf = unsafe { start.as_ref() };
-
                 if is_singleton {
                     self.state = None;
                 } else {
+                    // SAFETY: Covered by function safety doc
+                    let start_leaf = unsafe { start.as_ref() };
+
                     // PANIC SAFETY: We can unwrap here because `is_singleton` implies that `start`
                     // and `end` are different, which also implies that `start` does not point to
                     // the last/maximum leaf
@@ -118,12 +118,12 @@ impl<K, V, const PREFIX_LEN: usize> RawIterator<K, V, PREFIX_LEN> {
 
                 let next_back = *end;
 
-                // SAFETY: Covered by function safety doc
-                let end_leaf = unsafe { end.as_ref() };
-
                 if is_singleton {
                     self.state = None;
                 } else {
+                    // SAFETY: Covered by function safety doc
+                    let end_leaf = unsafe { end.as_ref() };
+
                     // PANIC SAFETY: We can unwrap here because `is_singleton` implies that `start`
                     // and `end` are different, which also implies that `end` does not point to
                     // the last/maximum leaf. The safety requirements of `RawIterator::new` also

--- a/src/raw/operations/delete.rs
+++ b/src/raw/operations/delete.rs
@@ -75,7 +75,7 @@ unsafe fn remove_child_from_inner_node_and_compress<
         // node.
         let mut children = inner_node.iter();
         let (child_key_byte, child_node_ptr) = children.next().expect("expected single child");
-        assert!(
+        debug_assert!(
             children.next().is_none(),
             "expected only a single child, not more"
         );
@@ -261,7 +261,7 @@ unsafe fn inner_delete_non_root_unchecked<K, V, const PREFIX_LEN: usize, A: Allo
 
     DeleteResult {
         new_root: Some(new_root),
-        _parent_node_change: Some(inner_node_modification),
+        parent_node_change: Some(inner_node_modification),
         deleted_leaf: leaf_node,
     }
 }
@@ -278,7 +278,7 @@ pub struct DeleteResult<K, V, const PREFIX_LEN: usize> {
     ///
     /// If `None`, that means the tree is now empty and there is no relevant
     /// parent node.
-    pub _parent_node_change: Option<DeleteParentNodeChange<K, V, PREFIX_LEN>>,
+    pub parent_node_change: Option<DeleteParentNodeChange<K, V, PREFIX_LEN>>,
 
     /// The leaf node that was successfully deleted.
     pub deleted_leaf: LeafNode<K, V, PREFIX_LEN>,
@@ -376,7 +376,7 @@ impl<K, V, const PREFIX_LEN: usize> DeletePoint<K, V, PREFIX_LEN> {
 
                 DeleteResult {
                     new_root: None,
-                    _parent_node_change: None,
+                    parent_node_change: None,
                     deleted_leaf: leaf_node,
                 }
             },

--- a/src/raw/operations/insert.rs
+++ b/src/raw/operations/insert.rs
@@ -975,6 +975,9 @@ impl<K, V, const PREFIX_LEN: usize> OverwritePoint<K, V, PREFIX_LEN> {
     }
 }
 
+type SearchControlFlow<K, V, const PREFIX_LEN: usize> =
+    ControlFlow<ExplicitMismatch<K, V, PREFIX_LEN>, Option<OpaqueNodePtr<K, V, PREFIX_LEN>>>;
+
 /// Check that the given inner node's prefix matches the relevant subslice of
 /// the given key.
 ///
@@ -988,10 +991,7 @@ unsafe fn test_prefix_identify_insert<K, V, N, const PREFIX_LEN: usize>(
     inner_ptr: NodePtr<PREFIX_LEN, N>,
     key: &[u8],
     current_depth: &mut usize,
-) -> Result<
-    ControlFlow<ExplicitMismatch<K, V, PREFIX_LEN>, Option<OpaqueNodePtr<K, V, PREFIX_LEN>>>,
-    InsertPrefixError,
->
+) -> Result<SearchControlFlow<K, V, PREFIX_LEN>, InsertPrefixError>
 where
     N: InnerNode<PREFIX_LEN, Key = K, Value = V>,
     K: AsBytes,

--- a/src/raw/representation.rs
+++ b/src/raw/representation.rs
@@ -990,10 +990,7 @@ pub trait InnerNode<const PREFIX_LEN: usize>: Node<PREFIX_LEN> + Sized + fmt::De
     fn read_full_prefix(
         &self,
         current_depth: usize,
-    ) -> (
-        &[u8],
-        Option<NodePtr<PREFIX_LEN, LeafNode<Self::Key, Self::Value, PREFIX_LEN>>>,
-    )
+    ) -> NodePrefix<'_, Self::Key, Self::Value, PREFIX_LEN>
     where
         Self::Key: AsBytes,
     {

--- a/src/raw/representation/header.rs
+++ b/src/raw/representation/header.rs
@@ -180,10 +180,7 @@ impl<const PREFIX_LEN: usize> Header<PREFIX_LEN> {
         &'a self,
         node: &'a N,
         current_depth: usize,
-    ) -> (
-        &'a [u8],
-        Option<NodePtr<PREFIX_LEN, LeafNode<N::Key, N::Value, PREFIX_LEN>>>,
-    )
+    ) -> NodePrefix<'a, N::Key, N::Value, PREFIX_LEN>
     where
         N::Key: AsBytes,
     {
@@ -223,6 +220,16 @@ impl<const PREFIX_LEN: usize> Header<PREFIX_LEN> {
         }
     }
 }
+
+/// This type represents the contents of an [`InnerNode`] prefix, either read
+/// directly from the prefix or fetched from a leaf node descendant.
+///
+/// The second value is the tuple will be `Some(_)` if the value was fetched
+/// from a leaf node.
+pub type NodePrefix<'a, K, V, const PREFIX_LEN: usize> = (
+    &'a [u8],
+    Option<NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>>,
+);
 
 impl<const PREFIX_LEN: usize> Debug for Header<PREFIX_LEN> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
- **Upgrade `rand` and remove deprecated `ZipfDistribution`**
- **More assertions in delete code path**
- **Redo override key/value display for `DotPrinter`**
- **Return parent node delete information**
- **Implement `extract_if` iterator and associated map methods**
