### PR TITLE
Prefix ops

### DIFF
--- a/src/raw/operations/insert/tests.rs
+++ b/src/raw/operations/insert/tests.rs
@@ -105,7 +105,9 @@ fn insert_prefix_key_errors() {
         }
     );
 
-    unsafe { deallocate_tree(tree, &Global) }
+    unsafe {
+        deallocate_tree(tree, &Global);
+    }
 }
 
 #[test]
@@ -125,7 +127,9 @@ fn insert_prefix_key_with_existing_prefix_errors() {
         }
     );
 
-    unsafe { deallocate_tree(tree, &Global) }
+    unsafe {
+        deallocate_tree(tree, &Global);
+    }
 }
 
 #[test]
@@ -179,7 +183,9 @@ fn insert_key_with_long_prefix_then_split() {
         &2
     );
 
-    unsafe { deallocate_tree(tree, &Global) }
+    unsafe {
+        deallocate_tree(tree, &Global);
+    }
 }
 
 #[test]
@@ -373,5 +379,7 @@ fn insert_existing_key_overwrite() {
         'W'
     );
 
-    unsafe { deallocate_tree(current_root, &Global) }
+    unsafe {
+        deallocate_tree(current_root, &Global);
+    }
 }

--- a/src/raw/operations/minmax.rs
+++ b/src/raw/operations/minmax.rs
@@ -73,7 +73,9 @@ mod tests {
 
         assert_eq!(min_leaf, max_leaf);
 
-        unsafe { deallocate_tree(root, &Global) }
+        unsafe {
+            deallocate_tree(root, &Global);
+        }
     }
 
     #[test]
@@ -108,7 +110,9 @@ mod tests {
             assert_eq!(max_leaf.key_ref().as_ref(), &[5, 5, 5]);
         }
 
-        unsafe { deallocate_tree(root, &Global) }
+        unsafe {
+            deallocate_tree(root, &Global);
+        }
     }
 
     #[test]
@@ -151,6 +155,8 @@ mod tests {
         );
         assert_eq!(max_leaf.key_ref().as_ref(), &[u8::MAX]);
 
-        unsafe { deallocate_tree(root, &Global) }
+        unsafe {
+            deallocate_tree(root, &Global);
+        }
     }
 }

--- a/src/raw/representation.rs
+++ b/src/raw/representation.rs
@@ -1142,7 +1142,7 @@ where
     /// This function requires that no other operation is concurrently modifying
     /// or reading the `this_ptr` leaf node and the sibling leaf nodes of the
     /// `old_leaf`.
-    pub unsafe fn replace(this_ptr: NodePtr<PREFIX_LEN, Self>, old_leaf: &mut Self) {
+    pub unsafe fn replace(this_ptr: NodePtr<PREFIX_LEN, Self>, old_leaf: &mut Self, force: bool) {
         // SAFETY: Covered by safety doc of this function
         let this = unsafe { this_ptr.as_mut() };
 
@@ -1155,11 +1155,13 @@ where
                 this.next.is_none(),
                 "next ptr should be None on insert into linked list"
             );
-            debug_assert_eq!(
-                this.key.as_bytes(),
-                old_leaf.key.as_bytes(),
-                "To replace a node, the key must be exactly the same"
-            );
+            if !force {
+                debug_assert_eq!(
+                    this.key.as_bytes(),
+                    old_leaf.key.as_bytes(),
+                    "To replace a node, the key must be exactly the same"
+                );
+            }
         }
 
         this.next = old_leaf.next;
@@ -1231,6 +1233,14 @@ impl<const PREFIX_LEN: usize, K, V> LeafNode<K, V, PREFIX_LEN> {
         K: AsBytes,
     {
         self.key.as_bytes().eq(possible_key)
+    }
+
+    /// Check that the key starts with the given slice.
+    pub fn starts_with(&self, key: &[u8]) -> bool
+    where
+        K: AsBytes,
+    {
+        self.key.as_bytes().starts_with(key)
     }
 
     /// This function removes this leaf node from its linked list.


### PR DESCRIPTION
Commit message of 159d4d0c128510ccf3ebc5fe782e966585dd5a43:
This commit adds 2 new operations, `get_prefix` and friends, and `force_insert`.
All `get_prefix` operations search the trie for a key that prefixes the given key (also matches a complete match).
Using these operations it is possible to act as if a value is assigned to a large (potentially infinite) subdomain of the keys.

For example:
```rust
let mut map = TreeMap::new();
// Assign 2 to "hello"
map.try_insert("hello", 2).unwrap();
// These queries get back the value 2 that was assigned to "hello",
// since these keys contain the prefix "hello"
assert_eq!(map.get_prefix("hello world!").copied(), Some(2));
assert_eq!(map.get_prefix("hello someone somewhere").copied(), Some(2));
// This string also contains the prefix "hello" and then the empty
// string, so this also matches.
assert_eq!(map.get_prefix("hello").copied(), Some(2));
```

The second new operation, called `force_insert`, complements the `get_prefix` operations by allowing the forced insertion of a key even if other keys exist that are a prefix of this new key.
It does this by removing all keys that prefix the new key before insertion.
If there are no keys that prefix the new key, it acts exactly like an infallible `try_insert`.

For example:
```rust
let mut map = TreeMap::new();
// Assign 2 to "hello world"
map.try_insert("hello world", 2).unwrap();
// Assign 2 to value "hello someone somewhere"
map.try_insert("hello someone somewhere", 2).unwrap();
// These queries obviously work.
assert_eq!(map.get_prefix("hello world!").copied(), Some(2));
assert_eq!(map.get_prefix("hello someone somewhere").copied(), Some(2));
// Now we decide we no longer want only "hello world" and "hello someone
// somewhere" to be assigned the value 2 but all keys starting with
// "hello".
map.force_insert("hello", 2);
// Using the `get_prefix` operations we still find 2 for the original
// keys, but we also find 2 for others.
assert_eq!(map.get_prefix("hello world!").copied(), Some(2));
assert_eq!(map.get_prefix("hello someone somewhere").copied(), Some(2));
assert_eq!(map.get_prefix("hello someone else somewhere").copied(), Some(2));
// The cardinality of the map has also been reduced to 1, since the
// original 2 key value pairs were removed.
assert_eq!(map.len(), 1);
```

This PR contains the commit from #49, so that I could fuzz test the implementation.

Some things I'm uncertain about:
- The names for the `prefix` ops, i.e. `get_prefix`, `get_prefix_mut` etc. Maybe there is a better term than prefix for this?
- The implementation of the prefix search point uses a lot of copy and pasted inner function from the exact search point function, only some of these were changed. I'm unsure if there is a better way to do this.