### PR TITLE
small improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["tree", "map", "collection", "radix-tree"]
 categories = ["data-structures"]
-rust-version = "1.78"
+# MSRV
+rust-version = "1.82"
 
 exclude = [
     "fuzz/",

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -27,7 +27,6 @@ pub fn get_first_key<K: AsBytes + Clone, V, const PREFIX_LEN: usize>(
     tree.first_key_value().unwrap().0
 }
 
-#[allow(dead_code)]
 pub fn get_middle_key<K: AsBytes + Clone, V, const PREFIX_LEN: usize>(
     tree: &TreeMap<K, V, PREFIX_LEN>,
     forward_step_size: usize,

--- a/benches/iai_callgrind.rs
+++ b/benches/iai_callgrind.rs
@@ -78,7 +78,6 @@ library_benchmark_group!(name = bench_remove_group; benchmarks = bench_remove_si
 
 // INSERT
 
-#[allow(dead_code)]
 fn insert_single_setup<K: AsBytes + Clone, V: Clone, const PREFIX_LEN: usize>(
     tree: &TreeMap<K, V, PREFIX_LEN>,
     key: &K,
@@ -97,7 +96,6 @@ fn bench_insert_single<K: AsBytes, V: Default, const PREFIX_LEN: usize>(
     tree.try_insert(key, V::default()).ok().flatten()
 }
 
-#[allow(dead_code)]
 fn insert_multiple_setup<K: AsBytes + Clone, V: Clone, const PREFIX_LEN: usize>(
     tree: &TreeMap<K, V, PREFIX_LEN>,
     keys: Vec<&K>,

--- a/benches/node/match_prefix.rs
+++ b/benches/node/match_prefix.rs
@@ -40,32 +40,44 @@ fn bench(c: &mut Criterion) {
     node256_large.write_child(99, leaf_opaque);
 
     macro_rules! generate_benches {
+        (single_bench $match_func:ident $b:ident $node:ident $key:ident $($current_depth:literal)?) => {
+            $b.iter(|| std::hint::black_box(
+                #[allow(unused_unsafe, unused_comparisons)]
+                unsafe {
+                    // SAFETY: covered by assert
+                    $(
+                        assert!($current_depth <= $key.len());
+                    )?
+                    $node.$match_func($key $(, $current_depth)?)
+                }
+            ))
+        };
         ($match_func:ident $($current_depth:literal)?) => {{
             let mut old_group = c.benchmark_group(stringify!($match_func));
             old_group.bench_function("node48/small/match", |b| {
-                b.iter(|| std::hint::black_box(node48_small.$match_func(key_small_match $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node48_small key_small_match $($current_depth)?)
             });
             old_group.bench_function("node48/small/mismatch", |b| {
-                b.iter(|| std::hint::black_box(node48_small.$match_func(key_small_mismatch $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node48_small key_small_mismatch $($current_depth)?)
             });
             old_group.bench_function("node48/large/match", |b| {
-                b.iter(|| std::hint::black_box(node48_large.$match_func(key_large_match $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node48_large key_large_match $($current_depth)?)
             });
             old_group.bench_function("node48/large/mismatch", |b| {
-                b.iter(|| std::hint::black_box(node48_large.$match_func(key_large_mismatch $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node48_large key_large_mismatch $($current_depth)?)
             });
 
             old_group.bench_function("node256/small/match", |b| {
-                b.iter(|| std::hint::black_box(node256_small.$match_func(key_small_match $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node256_small key_small_match $($current_depth)?)
             });
             old_group.bench_function("node256/small/mismatch", |b| {
-                b.iter(|| std::hint::black_box(node256_small.$match_func(key_small_mismatch $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node256_small key_small_mismatch $($current_depth)?)
             });
             old_group.bench_function("node256/large/match", |b| {
-                b.iter(|| std::hint::black_box(node256_large.$match_func(key_large_match $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node256_large key_large_match $($current_depth)?)
             });
             old_group.bench_function("node256/large/mismatch", |b| {
-                b.iter(|| std::hint::black_box(node256_large.$match_func(key_large_mismatch $(, $current_depth)?)));
+                generate_benches!(single_bench $match_func b node256_large key_large_mismatch $($current_depth)?)
             });
         }};
     }

--- a/examples/count_words.rs
+++ b/examples/count_words.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)] // this struct is used for its debug repr
+#[expect(dead_code)] // this struct is used for its debug repr
 struct WordStats {
     num_unique: u64,
     first_word: CString,

--- a/fuzz/fuzz_targets/tree_map_api.rs
+++ b/fuzz/fuzz_targets/tree_map_api.rs
@@ -167,9 +167,7 @@ libfuzzer_sys::fuzz_target!(|actions: Vec<Action>| {
                 next_value += 1;
 
                 let _ = tree.force_insert(key.clone(), value);
-                oracle.retain(|f, _| {
-                    !f.starts_with(&key) && !key.starts_with(f)
-                });
+                oracle.retain(|f, _| !f.starts_with(&key) && !key.starts_with(f));
                 oracle.insert(key, value);
             },
             Action::TryInsertMany(prefix, count) => {
@@ -240,6 +238,7 @@ libfuzzer_sys::fuzz_target!(|actions: Vec<Action>| {
         }
 
         assert!(tree.iter().eq(oracle.iter()), "{:?} != {:?}", tree, oracle);
+        assert_eq!(tree.len(), oracle.len());
         let _ = WellFormedChecker::check(&tree).expect("tree should be well-formed");
     }
 });

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -15,7 +15,7 @@ mod inner {
     #[cfg(test)]
     pub use std::alloc::AllocError;
 
-    #[allow(clippy::map_err_ignore)]
+    #[expect(clippy::map_err_ignore)]
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
         match alloc.allocate(layout) {
             Ok(ptr) => Ok(ptr.as_non_null_ptr()),
@@ -38,7 +38,7 @@ mod inner {
     #[cfg(test)]
     pub use allocator_api2::alloc::AllocError;
 
-    #[allow(clippy::map_err_ignore)]
+    #[expect(clippy::map_err_ignore)]
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
         match alloc.allocate(layout) {
             Ok(ptr) => Ok(ptr.cast()),
@@ -62,7 +62,7 @@ mod inner {
         ptr::NonNull,
     };
 
-    #[allow(clippy::missing_safety_doc)] // not exposed outside of this crate
+    #[expect(clippy::missing_safety_doc)] // not exposed outside of this crate
     pub unsafe trait Allocator {
         /// Attempts to allocate a block of memory.
         fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()>;

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -15,7 +15,6 @@ mod inner {
     #[cfg(test)]
     pub use std::alloc::AllocError;
 
-    #[expect(clippy::map_err_ignore)]
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
         match alloc.allocate(layout) {
             Ok(ptr) => Ok(ptr.as_non_null_ptr()),

--- a/src/bytes/mapped.rs
+++ b/src/bytes/mapped.rs
@@ -570,7 +570,7 @@ macro_rules! as_bytes_for_tuples {
                     // supports that
                     type Bytes = Box<[u8]>;
 
-                    #[allow(non_snake_case)]
+                    #[expect(non_snake_case)]
                     fn to_bytes(value: ($($ty,)+)) -> Self::Bytes {
                         let mut bytes = Vec::with_capacity(sum!(
                             $([< LEN_ $ty >],)+
@@ -589,7 +589,7 @@ macro_rules! as_bytes_for_tuples {
                         let remaining = &*bytes;
 
                         $(
-                            #[allow(non_snake_case)]
+                            #[expect(non_snake_case)]
                             let ([<bytes_ $ty>], remaining) = remaining.split_first_chunk::<[< LEN_ $ty >]>().unwrap();
                         )+
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -1081,12 +1081,12 @@ let _map = unsafe { TreeMap::from_raw_in(root, alloc) }.unwrap();
     /// Force inserts a key-value pair into the map.
     ///
     /// If the given key is not a prefix of any keys in the tree, this function
-    /// behaves just like [Self::try_insert].
-    /// If the given key is a prefix of some keys in the tree, or the other way
-    /// around, all these key value pairs are removed and this key value
-    /// pair is inserted in their place.
+    /// behaves just like [`Self::try_insert`]. If the given key is a prefix
+    /// of some keys in the tree, or the other way around, all these key
+    /// value pairs are removed and this key value pair is inserted in their
+    /// place.
     ///
-    /// See also: [Self::get_prefix] and friends.
+    /// See also: [`Self::get_prefix`] and friends.
     ///
     /// # Examples
     ///

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -2361,42 +2361,43 @@ mod tests {
         assert_eq!(tree.remove(&Box::from([])), None);
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn clone_tree_skewed() {
         let mut tree: TreeMap<Box<[u8]>, usize> = TreeMap::new();
-        for (v, k) in generate_keys_skewed(u8::MAX as usize).enumerate() {
+        for (v, k) in
+            generate_keys_skewed(if cfg!(miri) { 64 } else { u8::MAX as usize }).enumerate()
+        {
             tree.try_insert(k, v).unwrap();
         }
         let new_tree = tree.clone();
         assert!(tree == new_tree);
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn clone_tree_fixed_length() {
+        const KEY_DEPTH: usize = if cfg!(miri) { 4 } else { 8 };
         let mut tree: TreeMap<_, usize> = TreeMap::new();
-        for (v, k) in generate_key_fixed_length([2; 8]).enumerate() {
+        for (v, k) in generate_key_fixed_length([2; KEY_DEPTH]).enumerate() {
             tree.try_insert(k, v).unwrap();
         }
         let new_tree = tree.clone();
         assert!(tree == new_tree);
     }
 
-    #[cfg(not(miri))]
     #[test]
     fn clone_tree_with_prefix() {
+        const KEY_DEPTH: usize = if cfg!(miri) { 4 } else { 8 };
         let mut tree: TreeMap<Box<[u8]>, usize> = TreeMap::new();
         for (v, k) in generate_key_with_prefix(
-            [2; 8],
+            [2; KEY_DEPTH],
             [
                 PrefixExpansion {
                     base_index: 1,
-                    expanded_length: 12,
+                    expanded_length: if cfg!(miri) { 3 } else { 12 },
                 },
                 PrefixExpansion {
-                    base_index: 5,
-                    expanded_length: 8,
+                    base_index: 3,
+                    expanded_length: if cfg!(miri) { 2 } else { 8 },
                 },
             ],
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,15 @@
     feature = "nightly",
     feature(
         allocator_api,
-        core_intrinsics,
         hasher_prefixfree_extras,
         impl_trait_in_assoc_type,
+        likely_unlikely,
         maybe_uninit_array_assume_init,
         maybe_uninit_slice,
         portable_simd,
         slice_ptr_get,
     )
 )]
-#![cfg_attr(feature = "nightly", allow(incomplete_features, internal_features))]
-#![allow(clippy::type_complexity, unstable_name_collisions)]
 #![warn(clippy::dbg_macro)]
 #![deny(
     missing_docs,

--- a/src/raw/representation.rs
+++ b/src/raw/representation.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     alloc::{do_alloc, Allocator},
-    rust_nightly_apis::assume,
     tagged_pointer::TaggedPointer,
     AsBytes,
 };
@@ -950,7 +949,7 @@ pub trait InnerNode<const PREFIX_LEN: usize>: Node<PREFIX_LEN> + Sized + fmt::De
     /// # Safety
     /// `current_depth` must be less than or equal to `key.len()`
     #[inline]
-unsafe fn match_full_prefix(
+    unsafe fn match_full_prefix(
         &self,
         key: &[u8],
         current_depth: usize,
@@ -958,14 +957,14 @@ unsafe fn match_full_prefix(
     where
         Self::Key: AsBytes,
     {
-        #[allow(unused_unsafe)]
         unsafe {
             // SAFETY: Since we are iterating the key and prefixes, we
             // expect that the depth never exceeds the key len.
             // Because if this happens we ran out of bytes in the key to match
             // and the whole process should be already finished
-            assume!(current_depth <= key.len());
+            std::hint::assert_unchecked(current_depth <= key.len());
         }
+
         let (prefix, leaf_ptr) = self.read_full_prefix(current_depth);
         let key = &key[current_depth..];
 

--- a/src/raw/representation.rs
+++ b/src/raw/representation.rs
@@ -948,9 +948,9 @@ pub trait InnerNode<const PREFIX_LEN: usize>: Node<PREFIX_LEN> + Sized + fmt::De
     /// needs to search a descendant leaf node to find implicit bytes.
     ///
     /// # Safety
-    ///  - `current_depth` > key len
+    /// `current_depth` must be less than or equal to `key.len()`
     #[inline]
-    fn match_full_prefix(
+unsafe fn match_full_prefix(
         &self,
         key: &[u8],
         current_depth: usize,
@@ -1003,22 +1003,20 @@ pub trait InnerNode<const PREFIX_LEN: usize>: Node<PREFIX_LEN> + Sized + fmt::De
 
     /// Returns the minimum child pointer from this node and it's key
     ///
-    /// # Safety
-    ///  - Since this is a [`InnerNode`] we assume that the we have at least one
-    ///    child, (more strictly we have 2, because with one child the node
-    ///    would have collapsed) so in this way we can avoid the [`Option`].
-    ///    This is safe because if we had no children this current node should
-    ///    have been deleted.
+    /// Since this is a [`InnerNode`] we assume that the we have at least one
+    /// child, (more strictly we have 2, because with one child the node would
+    /// have collapsed) so in this way we can avoid the [`Option`]. This is safe
+    /// because if we had no children this current node should have been
+    /// deleted.
     fn min(&self) -> (u8, OpaqueNodePtr<Self::Key, Self::Value, PREFIX_LEN>);
 
     /// Returns the maximum child pointer from this node and it's key
     ///
-    /// # Safety
-    ///  - Since this is a [`InnerNode`] we assume that the we have at least one
-    ///    child, (more strictly we have 2, because with one child the node
-    ///    would have collapsed) so in this way we can avoid the [`Option`].
-    ///    This is safe because if we had, no children this current node should
-    ///    have been deleted.
+    /// Since this is a [`InnerNode`] we assume that the we have at least one
+    /// child, (more strictly we have 2, because with one child the node would
+    /// have collapsed) so in this way we can avoid the [`Option`]. This is safe
+    /// because if we had, no children this current node should have been
+    /// deleted.
     fn max(&self) -> (u8, OpaqueNodePtr<Self::Key, Self::Value, PREFIX_LEN>);
 }
 

--- a/src/raw/representation/header.rs
+++ b/src/raw/representation/header.rs
@@ -263,7 +263,7 @@ mod tests {
         assert_eq!(h.prefix_len(), 4);
 
         h.ltrim_by(4);
-        assert_eq!(h.read_prefix(), &[]);
+        assert_eq!(h.read_prefix(), &[] as &[u8]);
         assert_eq!(h.prefix_len(), 0);
     }
 

--- a/src/raw/representation/inner_node_256.rs
+++ b/src/raw/representation/inner_node_256.rs
@@ -190,8 +190,6 @@ impl<K, V, const PREFIX_LEN: usize> InnerNode<PREFIX_LEN> for InnerNode256<K, V,
     #[cfg(feature = "nightly")]
     #[cfg_attr(test, mutants::skip)]
     fn min(&self) -> (u8, OpaqueNodePtr<K, V, PREFIX_LEN>) {
-        use crate::rust_nightly_apis::assume;
-
         // SAFETY: Due to niche optimization Option<NonNull> has the same
         // size as NonNull and NonNull has the same size as usize
         // so it's safe to transmute
@@ -223,7 +221,7 @@ impl<K, V, const PREFIX_LEN: usize> InnerNode<PREFIX_LEN> for InnerNode256<K, V,
         unsafe {
             // SAFETY: key can be at up to 256, but we know that we have
             // at least one inner child, it's guarantee to be in bounds
-            assume!(key < self.child_pointers.len());
+            std::hint::assert_unchecked(key < self.child_pointers.len());
         }
 
         // SAFETY: Covered by the containing function
@@ -246,8 +244,6 @@ impl<K, V, const PREFIX_LEN: usize> InnerNode<PREFIX_LEN> for InnerNode256<K, V,
     #[cfg(feature = "nightly")]
     #[cfg_attr(test, mutants::skip)]
     fn max(&self) -> (u8, OpaqueNodePtr<K, V, PREFIX_LEN>) {
-        use crate::rust_nightly_apis::assume;
-
         // SAFETY: Due to niche optimization Option<NonNull> has the same
         // size as NonNull and NonNull has the same size as usize
         // so it's safe to transmute
@@ -281,7 +277,7 @@ impl<K, V, const PREFIX_LEN: usize> InnerNode<PREFIX_LEN> for InnerNode256<K, V,
 
         unsafe {
             // SAFETY: idx can be at up to 255, so it's in bounds
-            assume!(key < self.child_pointers.len());
+            std::hint::assert_unchecked(key < self.child_pointers.len());
         }
 
         // SAFETY: covered by the containing function

--- a/src/raw/representation/inner_node_compressed.rs
+++ b/src/raw/representation/inner_node_compressed.rs
@@ -420,6 +420,8 @@ impl<K, V, const PREFIX_LEN: usize> SearchInnerNodeCompressed for InnerNode4<K, 
 
         let mut child_index = 0;
         for key in keys {
+            // Might be able to remove this `allow` once we bump the MSRV again. I'm not
+            // sure which version exactly (in between 1.82 and 1.88) has the fix.
             #[allow(clippy::comparison_chain)]
             if key_fragment < *key {
                 return WritePoint::Shift(child_index);
@@ -581,6 +583,8 @@ impl<K, V, const PREFIX_LEN: usize> SearchInnerNodeCompressed for InnerNode16<K,
 
         let mut child_index = 0;
         for key in keys {
+            // Might be able to remove this `allow` once we bump the MSRV again. I'm not
+            // sure which version exactly (in between 1.82 and 1.88) has the fix.
             #[allow(clippy::comparison_chain)]
             if key_fragment < *key {
                 return WritePoint::Shift(child_index);

--- a/src/rust_nightly_apis.rs
+++ b/src/rust_nightly_apis.rs
@@ -113,78 +113,31 @@ pub fn hasher_write_length_prefix<H: std::hash::Hasher>(state: &mut H, num_entri
     }
 }
 
-/// Constructs a new boxed slice with uninitialized contents.
-///
-/// **This is a unstable API copied from the Rust standard library, tracking
-/// issue is [#63291][issue-63291]**
-///
-/// [issue-63291]: https://github.com/rust-lang/rust/issues/63291
-#[inline]
-pub fn box_new_uninit_slice<T>(len: usize) -> Box<[std::mem::MaybeUninit<T>]> {
-    #[cfg(feature = "nightly")]
-    {
-        Box::new_uninit_slice(len)
-    }
-
-    #[cfg(not(feature = "nightly"))]
-    {
-        Vec::from_iter((0..len).map(|_| std::mem::MaybeUninit::uninit())).into_boxed_slice()
-    }
-}
-
-/// Informs the optimizer that a condition is always true.
-/// If the condition is false, the behavior is undefined.
-///
-/// No code is generated for this intrinsic, but the optimizer will try
-/// to preserve it (and its condition) between passes, which may interfere
-/// with optimization of surrounding code and reduce performance. It should
-/// not be used if the invariant can be discovered by the optimizer on its
-/// own, or if it does not enable any significant optimizations.
-///
-/// This intrinsic does not have a stable counterpart.
-///
-/// **This is a unstable API copied from the Rust standard library**
-macro_rules! assume {
-    ($b:expr) => {
-        debug_assert!($b);
-        #[cfg(feature = "nightly")]
-        std::intrinsics::assume($b)
-    };
-}
-
-pub(crate) use assume;
-
-/// Hints to the compiler that branch condition is likely to be true.
+/// Hints to the compiler that a branch condition is unlikely to be true.
 /// Returns the value passed to it.
 ///
-/// Any use other than with `if` statements will probably not have an effect.
+/// It can be used with `if` or boolean `match` expressions.
 ///
-/// Note that, unlike most intrinsics, this is safe to call;
-/// it does not require an `unsafe` block.
-/// Therefore, implementations must not require the user to uphold
-/// any safety invariants.
-///
-/// This intrinsic does not have a stable counterpart.
+/// When used outside of a branch condition, it may still influence a nearby
+/// branch, but
+/// probably will not have any effect.
 ///
 /// **This is a unstable API copied from the Rust standard library**
 #[cfg(feature = "nightly")]
 macro_rules! likely {
     ($b:expr) => {
-        std::intrinsics::likely($b)
+        std::hint::likely($b)
     };
 }
 
-/// Hints to the compiler that branch condition is likely to be true.
+/// Hints to the compiler that a branch condition is unlikely to be true.
 /// Returns the value passed to it.
 ///
-/// Any use other than with `if` statements will probably not have an effect.
+/// It can be used with `if` or boolean `match` expressions.
 ///
-/// Note that, unlike most intrinsics, this is safe to call;
-/// it does not require an `unsafe` block.
-/// Therefore, implementations must not require the user to uphold
-/// any safety invariants.
-///
-/// This intrinsic does not have a stable counterpart.
+/// When used outside of a branch condition, it may still influence a nearby
+/// branch, but
+/// probably will not have any effect.
 ///
 /// **This is a unstable API copied from the Rust standard library**
 #[cfg(not(feature = "nightly"))]
@@ -196,37 +149,33 @@ macro_rules! likely {
 
 pub(crate) use likely;
 
-/// Hints to the compiler that branch condition is likely to be false.
-/// Returns the value passed to it.
+/// Hints to the compiler that given path is cold, i.e., unlikely to be taken.
+/// The compiler may choose to optimize paths that are not cold at the expense
+/// of paths that are cold.
 ///
 /// Any use other than with `if` statements will probably not have an effect.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
-/// it does not require an `unsafe` block.
-/// Therefore, implementations must not require the user to uphold
-/// any safety invariants.
-///
-/// This intrinsic does not have a stable counterpart.
+/// it does not require an `unsafe` block. Therefore, implementations must not
+/// require the user to uphold any safety invariants.
 ///
 /// **This is a unstable API copied from the Rust standard library**
 #[cfg(feature = "nightly")]
 macro_rules! unlikely {
     ($b:expr) => {
-        std::intrinsics::unlikely($b)
+        std::hint::unlikely($b)
     };
 }
 
-/// Hints to the compiler that branch condition is likely to be false.
-/// Returns the value passed to it.
+/// Hints to the compiler that given path is cold, i.e., unlikely to be taken.
+/// The compiler may choose to optimize paths that are not cold at the expense
+/// of paths that are cold.
 ///
 /// Any use other than with `if` statements will probably not have an effect.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
-/// it does not require an `unsafe` block.
-/// Therefore, implementations must not require the user to uphold
-/// any safety invariants.
-///
-/// This intrinsic does not have a stable counterpart.
+/// it does not require an `unsafe` block. Therefore, implementations must not
+/// require the user to uphold any safety invariants.
 ///
 /// **This is a unstable API copied from the Rust standard library**
 #[cfg(not(feature = "nightly"))]
@@ -269,13 +218,6 @@ pub(crate) mod ptr {
         let offset = dest_addr.wrapping_sub(self_addr);
 
         ptr.wrapping_byte_offset(offset)
-    }
-
-    #[cfg(all(test, any(feature = "allocator-api2", feature = "nightly")))]
-    #[inline]
-    #[cfg(feature = "nightly")]
-    pub fn mut_with_addr<T>(ptr: *mut T, addr: usize) -> *mut T {
-        ptr.with_addr(addr)
     }
 
     #[cfg(test)]

--- a/src/rust_nightly_apis.rs
+++ b/src/rust_nightly_apis.rs
@@ -246,7 +246,7 @@ pub(crate) mod ptr {
 
     #[inline]
     #[cfg(not(feature = "nightly"))]
-    #[allow(clippy::transmutes_expressible_as_ptr_casts)]
+    #[expect(clippy::transmutes_expressible_as_ptr_casts)]
     pub fn mut_addr<T>(ptr: *mut T) -> usize {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler
         // intrinsic. SAFETY: Pointer-to-integer transmutes are valid (if you

--- a/src/tagged_pointer.rs
+++ b/src/tagged_pointer.rs
@@ -56,10 +56,6 @@ impl<P, const MIN_BITS: u32> TaggedPointer<P, MIN_BITS> {
     /// # Panics
     ///  - Panics if the given `pointer` is not aligned according to the minimum
     ///    alignment required for the `P` type.
-    //
-    // The API can take a raw pointer here because it does not dereference the pointer in the body
-    // of the function.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn new(pointer: *mut P) -> Option<TaggedPointer<P, MIN_BITS>> {
         if pointer.is_null() {
             return None;

--- a/src/tests_common.rs
+++ b/src/tests_common.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashSet, iter};
 
+#[cfg(test)]
 use crate::{
     alloc::Global,
     raw::{InsertPrefixError, InsertResult, OpaqueNodePtr},
@@ -325,7 +326,7 @@ pub fn generate_key_with_prefix<const KEY_LENGTH: usize>(
         .map(move |key| apply_expansions_to_key(&key, &full_key_template, &sorted_expansions))
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub(crate) unsafe fn insert_unchecked<'a, K, V, const PREFIX_LEN: usize>(
     root: OpaqueNodePtr<K, V, PREFIX_LEN>,
     key: K,
@@ -340,7 +341,7 @@ where
     Ok(unsafe { insert_point.apply(key, value, &Global) })
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub(crate) fn setup_tree_from_entries<K, V, const PREFIX_LEN: usize>(
     entries_it: impl Iterator<Item = (K, V)>,
 ) -> OpaqueNodePtr<K, V, PREFIX_LEN>
@@ -356,16 +357,15 @@ where
     TreeMap::into_raw(tree).unwrap()
 }
 
-#[cfg(test)]
+// disabled for miri because the runtime is too large, and this does not test
+// any safety-critical stuff
+#[cfg(all(test, not(miri)))]
 mod tests {
     use crate::TreeMap;
 
     use super::*;
 
     #[test]
-    // disabled for miri because the runtime is too large, and this does not test any
-    // safety-critical stuff
-    #[cfg(not(miri))]
     fn key_generator_returns_expected_number_of_entries() {
         #[track_caller]
         fn check<K: AsBytes>(it: impl IntoIterator<Item = K>, expected_num_entries: usize) {


### PR DESCRIPTION
- **Actually bump MSRV to 1.82**
- **Switch lint `allow`s to `expect`s where possible**
- **Fix incorrect safety requirements around insert**
- **Upgrade to stable versions of nightly APIs after MSRV bump**
