### PR TITLE
feat: no_std support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+- no_std support with `std` feature flag that is enabled by default.
+
 ## [0.4.0] - 2025-07-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,11 @@ bytemuck = { version = "1.16.1", features = ["min_const_generics"] }
 paste = "1.0.15"
 
 [features]
+default = ["std"]
 nightly = []
 bench-perf-events = []
 allocator-api2 = ["dep:allocator-api2"]
+std = []
 
 [dev-dependencies]
 argh = "0.1.12"
@@ -57,3 +59,19 @@ harness = false
 
 [profile.bench]
 debug = true
+
+[[example]]
+name = "tree_viz"
+required-features = ["std"]
+
+[[test]]
+name = "memory_usage_fixed_length_dense"
+required-features = ["std"]
+
+[[test]]
+name = "memory_usage_large_prefixes"
+required-features = ["std"]
+
+[[test]]
+name = "memory_usage_skewed"
+required-features = ["std"]

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -32,6 +32,7 @@ do
     # We test benchmarks in release, otherwise they are too slow
     cargo "${TOOLCHAIN_ARG}" test   $extra_args --benches --release
     cargo "${TOOLCHAIN_ARG}" test   $extra_args --doc
+    cargo "${TOOLCHAIN_ARG}" test  $extra_args --lib --bins --examples --tests --no-default-features
 
     cargo "${TOOLCHAIN_ARG}" clippy $extra_args --all-targets
     cargo "${TOOLCHAIN_ARG}" doc    $extra_args --no-deps --document-private-items

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -9,11 +9,12 @@ pub(crate) use self::inner::AllocError;
 // This is used when building for `std`.
 #[cfg(feature = "nightly")]
 mod inner {
-    pub use std::alloc::{Allocator, Global};
-    use std::{alloc::Layout, ptr::NonNull};
+    use alloc::alloc::Layout;
+    pub use alloc::alloc::{Allocator, Global};
+    use core::ptr::NonNull;
 
     #[cfg(test)]
-    pub use std::alloc::AllocError;
+    pub use alloc::alloc::AllocError;
 
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
         match alloc.allocate(layout) {
@@ -31,8 +32,9 @@ mod inner {
 // `core::alloc::Allocator`.
 #[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
 mod inner {
+    use alloc::alloc::Layout;
     pub use allocator_api2::alloc::{Allocator, Global};
-    use std::{alloc::Layout, ptr::NonNull};
+    use core::ptr::NonNull;
 
     #[cfg(test)]
     pub use allocator_api2::alloc::AllocError;
@@ -56,10 +58,8 @@ mod inner {
 // or `nightly` without disturbing users that don't want to use it.
 #[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
 mod inner {
-    use std::{
-        alloc::{alloc, dealloc, Layout},
-        ptr::NonNull,
-    };
+    use alloc::alloc::{alloc, dealloc, Layout};
+    use core::ptr::NonNull;
 
     #[expect(clippy::missing_safety_doc)] // not exposed outside of this crate
     pub unsafe trait Allocator {

--- a/src/collections/map/entry.rs
+++ b/src/collections/map/entry.rs
@@ -1,7 +1,7 @@
-use std::mem::replace;
+use core::mem::replace;
 
 use crate::{
-    alloc::{Allocator, Global},
+    allocator::{Allocator, Global},
     raw::{DeletePoint, InsertParentNodeChange, InsertPoint, InsertResult, TreePath},
     AsBytes, TreeMap,
 };
@@ -382,7 +382,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CString;
+    #[cfg(feature = "std")]
+    use alloc::{boxed::Box, vec::Vec};
+    use alloc::{ffi::CString, string::String};
 
     use crate::TreeMap;
 
@@ -516,6 +518,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn regression_01cf3c554fd1da17307a8451972a823db68d4c04() {
         // [
@@ -543,6 +546,7 @@ mod tests {
         let _ = crate::visitor::WellFormedChecker::check(&tree).unwrap();
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn regression_a1d834472bf0d652a9ad39eab5d6e173825c80dc() {
         // [
@@ -596,6 +600,7 @@ mod tests {
         let _ = crate::visitor::WellFormedChecker::check(&tree).unwrap();
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn regression_0a766df3f0e1c88c45e5ff54d247731a8efefe08() {
         // [
@@ -680,6 +685,7 @@ mod tests {
         let _ = crate::visitor::WellFormedChecker::check(&tree).unwrap();
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn empty_tree_insert_remove() {
         let mut tree = TreeMap::<[u8; 0], i32>::new();
@@ -689,6 +695,7 @@ mod tests {
         let _ = crate::visitor::WellFormedChecker::check(&tree).unwrap();
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn replace_existing_leaf() {
         let mut tree = TreeMap::<[u8; 2], i32>::new();

--- a/src/collections/map/iterators/extract_if.rs
+++ b/src/collections/map/iterators/extract_if.rs
@@ -1,11 +1,11 @@
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     collections::map::TreeMap,
     map::{find_leaf_pointer_for_bound, validate_range_bounds},
     raw::{search_for_delete_point, LeafNode, NodePtr, RawIterator},
     AsBytes,
 };
-use std::{iter::FusedIterator, ops::Bound};
+use core::{iter::FusedIterator, ops::Bound};
 
 /// An iterator which uses a closure to determine if an element should be
 /// removed.
@@ -207,6 +207,7 @@ mod tests {
         tests_common::{generate_key_fixed_length, swap},
         TreeMap,
     };
+    use alloc::vec::Vec;
 
     #[test]
     fn extract_if_simple() {
@@ -268,6 +269,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn tree_map_extract_if_interrupted() {
         // Exactly the same as `retain`, on panic the iteration should stop.
 

--- a/src/collections/map/iterators/fuzzy/tests.rs
+++ b/src/collections/map/iterators/fuzzy/tests.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use alloc::ffi::CString;
 
 use crate::{
     raw::visitor::{TreeStats, TreeStatsCollector},

--- a/src/collections/map/iterators/into_iter.rs
+++ b/src/collections/map/iterators/into_iter.rs
@@ -1,11 +1,11 @@
-use std::{
+use core::{
     iter::FusedIterator,
     mem::{self, ManuallyDrop},
     ptr,
 };
 
 use crate::{
-    alloc::{Allocator, Global},
+    allocator::{Allocator, Global},
     map::DEFAULT_PREFIX_LEN,
     raw::{deallocate_leaves, deallocate_tree_non_leaves, NodePtr, RawIterator},
     TreeMap,
@@ -238,10 +238,8 @@ impl<K, V, const PREFIX_LEN: usize, A: Allocator> ExactSizeIterator
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    };
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::{tests_common::swap, AsBytes, NoPrefixesBytes, OrderedBytes};
 
@@ -303,13 +301,13 @@ mod tests {
     }
 
     impl<T: Ord> Ord for DropCounter<T> {
-        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
             self.1.cmp(&other.1)
         }
     }
 
     impl<T: PartialOrd> PartialOrd for DropCounter<T> {
-        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
             self.1.partial_cmp(&other.1)
         }
     }

--- a/src/collections/map/iterators/iterator.rs
+++ b/src/collections/map/iterators/iterator.rs
@@ -1,7 +1,7 @@
-use std::iter::FusedIterator;
+use core::iter::FusedIterator;
 
 use crate::{
-    alloc::{Allocator, Global},
+    allocator::{Allocator, Global},
     map::DEFAULT_PREFIX_LEN,
     raw::RawIterator,
     TreeMap,
@@ -249,9 +249,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{tests_common::generate_key_fixed_length, TreeMap};
-
     use super::*;
+    use crate::{tests_common::generate_key_fixed_length, TreeMap};
+    use alloc::{boxed::Box, vec::Vec};
 
     #[test]
     fn iterators_are_send_sync() {

--- a/src/collections/map/iterators/prefix.rs
+++ b/src/collections/map/iterators/prefix.rs
@@ -1,10 +1,10 @@
 use crate::{
-    alloc::{Allocator, Global},
+    allocator::{Allocator, Global},
     map::DEFAULT_PREFIX_LEN,
     raw::{maximum_unchecked, minimum_unchecked, RawIterator},
     AsBytes, TreeMap,
 };
-use std::iter::FusedIterator;
+use core::iter::FusedIterator;
 
 use super::{
     find_terminating_node, InnerNodeSearchResult, InnerNodeSearchResultReason,
@@ -188,6 +188,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{tests_common::swap, TreeMap};
+    use alloc::vec::Vec;
 
     use super::*;
 

--- a/src/collections/map/iterators/range.rs
+++ b/src/collections/map/iterators/range.rs
@@ -1,7 +1,7 @@
 //! This module contains types and functions relating to iterating over a
 //! range of the [`TreeMap`].
 
-use std::{
+use core::{
     cmp::Ordering,
     fmt,
     iter::FusedIterator,
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    alloc::{Allocator, Global},
+    allocator::{Allocator, Global},
     map::{NonEmptyTree, DEFAULT_PREFIX_LEN},
     raw::{
         maximum_unchecked, minimum_unchecked, AttemptOptimisticPrefixMatch, ConcreteNodePtr,
@@ -615,6 +615,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::tests_common::{generate_key_with_prefix, swap, PrefixExpansion};
+    use alloc::{boxed::Box, vec::Vec};
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![cfg_attr(
     feature = "nightly",
     feature(
@@ -37,7 +38,13 @@
 //!
 //! [ART paper]: http://web.archive.org/web/20240508000744/https://db.in.tum.de/~leis/papers/ART.pdf
 
-mod alloc;
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+mod allocator;
 mod bytes;
 mod collections;
 mod rust_nightly_apis;

--- a/src/raw/iterator.rs
+++ b/src/raw/iterator.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use super::{LeafNode, NodePtr};
 

--- a/src/raw/operations/clone.rs
+++ b/src/raw/operations/clone.rs
@@ -1,12 +1,13 @@
 //! This module contains the implementation of `clone()` for the trie.
 
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     raw::{
         ConcreteInnerNodePtr, ConcreteNodePtr, InnerNode, LeafNode, Node, NodePtr, OpaqueNodePtr,
     },
     AsBytes,
 };
+use alloc::vec::Vec;
 
 /// The result of cloning a trie
 #[derive(Debug)]
@@ -276,9 +277,10 @@ pub unsafe fn clone_unchecked<
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
-    use std::fmt;
+    use alloc::boxed::Box;
+    use core::fmt;
 
     use crate::{
         tests_common::{

--- a/src/raw/operations/deallocate.rs
+++ b/src/raw/operations/deallocate.rs
@@ -1,7 +1,8 @@
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     raw::{ConcreteNodePtr, InnerNode, LeafNode, NodePtr, OpaqueNodePtr, RawIterator},
 };
+use alloc::vec::Vec;
 
 /// Deallocate all the leaf nodes in the linked list starting that are within
 /// the given iterator.

--- a/src/raw/operations/delete.rs
+++ b/src/raw/operations/delete.rs
@@ -1,7 +1,7 @@
-use std::fmt;
+use core::fmt;
 
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     raw::{
         operations::lookup, ConcreteNodePtr, InnerNode, LeafNode, NodePtr, OpaqueNodePtr, TreePath,
         TreePathSearch,

--- a/src/raw/operations/delete/tests.rs
+++ b/src/raw/operations/delete/tests.rs
@@ -1,9 +1,13 @@
 use super::*;
 use crate::{
-    alloc::Global,
+    allocator::Global,
     raw::{deallocate_tree, search_unchecked, NodeType},
     tests_common::{generate_key_with_prefix, setup_tree_from_entries, swap, PrefixExpansion},
     TreeMap,
+};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
 };
 
 #[test]

--- a/src/raw/operations/insert.rs
+++ b/src/raw/operations/insert.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     raw::{
         deallocate_tree, maximum_unchecked, minimum_unchecked, ConcreteNodePtr, ExplicitMismatch,
         InnerNode, InnerNode4, LeafNode, NodePtr, OpaqueNodePtr, PrefixMatch, TreePath,
@@ -8,7 +8,8 @@ use crate::{
     rust_nightly_apis::{likely, unlikely},
     AsBytes,
 };
-use std::{
+use alloc::boxed::Box;
+use core::{
     error::Error,
     fmt,
     marker::PhantomData,
@@ -362,7 +363,7 @@ impl<K, V, const PREFIX_LEN: usize> InsertPoint<K, V, PREFIX_LEN> {
                     // expect that the depth never exceeds the key len.
                     // Because if this happens we ran out of bytes in the key to match
                     // and the whole process should be already finished
-                    std::hint::assert_unchecked(
+                    core::hint::assert_unchecked(
                         key_bytes_used + mismatch.matched_bytes < key_bytes.len(),
                     );
                 }
@@ -485,14 +486,14 @@ impl<K, V, const PREFIX_LEN: usize> InsertPoint<K, V, PREFIX_LEN> {
                     // guarantees that the amount of bytes used is always < len of the key or key in
                     // the leaf if this was not true, then a
                     // [`InsertPrefixError`] would already be triggered
-                    std::hint::assert_unchecked(key_bytes_used < leaf_bytes.len());
-                    std::hint::assert_unchecked(key_bytes_used < key_bytes.len());
-                    std::hint::assert_unchecked(new_key_bytes_used < leaf_bytes.len());
-                    std::hint::assert_unchecked(new_key_bytes_used < key_bytes.len());
+                    core::hint::assert_unchecked(key_bytes_used < leaf_bytes.len());
+                    core::hint::assert_unchecked(key_bytes_used < key_bytes.len());
+                    core::hint::assert_unchecked(new_key_bytes_used < leaf_bytes.len());
+                    core::hint::assert_unchecked(new_key_bytes_used < key_bytes.len());
 
                     // SAFETY: This is safe by construction, since new_key_bytes_used =
                     // key_bytes_used + x
-                    std::hint::assert_unchecked(key_bytes_used <= new_key_bytes_used);
+                    core::hint::assert_unchecked(key_bytes_used <= new_key_bytes_used);
                 }
 
                 let mut new_n4 = InnerNode4::from_prefix(
@@ -1091,8 +1092,8 @@ where
                     // which would lead to this not holding, but since it already checked we know
                     // that current_depth < len of the key and the key in the leaf. But there is an
                     // edge case, if the root of the tree is a leaf than the depth can be = len
-                    std::hint::assert_unchecked(current_depth <= leaf_bytes.len());
-                    std::hint::assert_unchecked(current_depth <= key_bytes.len());
+                    core::hint::assert_unchecked(current_depth <= leaf_bytes.len());
+                    core::hint::assert_unchecked(current_depth <= key_bytes.len());
                 }
 
                 let prefix_size = leaf_bytes[current_depth..]
@@ -1133,7 +1134,7 @@ where
                     // that current_depth < len of the key and the key in the leaf. And also the
                     // only edge case can occur in the Leaf node, but if we reach a leaf not the
                     // function returns early, so it's impossible to be <=
-                    std::hint::assert_unchecked(current_depth < key_bytes.len());
+                    core::hint::assert_unchecked(current_depth < key_bytes.len());
                 }
 
                 match next_child_node {
@@ -1245,8 +1246,8 @@ where
                     // which would lead to this not holding, but since it already checked we know
                     // that current_depth < len of the key and the key in the leaf. But there is an
                     // edge case, if the root of the tree is a leaf than the depth can be = len
-                    std::hint::assert_unchecked(current_depth <= leaf_bytes.len());
-                    std::hint::assert_unchecked(current_depth <= key_bytes.len());
+                    core::hint::assert_unchecked(current_depth <= leaf_bytes.len());
+                    core::hint::assert_unchecked(current_depth <= key_bytes.len());
                 }
 
                 let prefix_size = leaf_bytes[current_depth..]
@@ -1300,7 +1301,7 @@ where
                     // that current_depth < len of the key and the key in the leaf. And also the
                     // only edge case can occur in the Leaf node, but if we reach a leaf not the
                     // function returns early, so it's impossible to be <=
-                    std::hint::assert_unchecked(current_depth < key_bytes.len());
+                    core::hint::assert_unchecked(current_depth < key_bytes.len());
                 }
 
                 match next_child_node {

--- a/src/raw/operations/insert/tests.rs
+++ b/src/raw/operations/insert/tests.rs
@@ -1,10 +1,14 @@
 use crate::{
-    alloc::Global,
+    allocator::Global,
     raw::{
         deallocate_tree, search_unchecked, InnerNode, InnerNode4, InnerNodeCompressed,
         InsertPrefixError, LeafNode, NodePtr, NodeType, OpaqueNodePtr,
     },
     tests_common::{generate_keys_skewed, insert_unchecked, setup_tree_from_entries},
+};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
 };
 
 #[test]

--- a/src/raw/operations/lookup.rs
+++ b/src/raw/operations/lookup.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::{
     raw::{

--- a/src/raw/operations/lookup/tests.rs
+++ b/src/raw/operations/lookup/tests.rs
@@ -6,6 +6,7 @@ use crate::{
     tests_common::{generate_key_with_prefix, swap, PrefixExpansion},
     TreeMap,
 };
+use alloc::{boxed::Box, string::String};
 
 #[test]
 fn lookup_on_non_copy_leaf() {

--- a/src/raw/operations/minmax.rs
+++ b/src/raw/operations/minmax.rs
@@ -53,11 +53,15 @@ pub unsafe fn maximum_unchecked<K, V, const PREFIX_LEN: usize>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        alloc::Global,
+        allocator::Global,
         raw::{
             deallocate_tree, maximum_unchecked, minimum_unchecked, LeafNode, NodePtr, OpaqueNodePtr,
         },
         tests_common::{generate_key_fixed_length, generate_keys_skewed, insert_unchecked},
+    };
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
     };
 
     #[test]

--- a/src/raw/representation/header.rs
+++ b/src/raw/representation/header.rs
@@ -1,6 +1,6 @@
 //! Different header type
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::{
     raw::{minimum_unchecked, InnerNode, LeafNode, NodePtr},
@@ -95,10 +95,10 @@ impl<const PREFIX_LEN: usize> Header<PREFIX_LEN> {
             // we used the node to match the number of bytes,
             // by this we know that len < prefix len, but since we + 1,
             // to skip the key byte we have that len <= prefix len
-            std::hint::assert_unchecked(end <= self.prefix.len());
+            core::hint::assert_unchecked(end <= self.prefix.len());
 
             // SAFETY: This is by construction end = begin + len
-            std::hint::assert_unchecked(begin <= end);
+            core::hint::assert_unchecked(begin <= end);
         }
         self.prefix.copy_within(begin..end, 0);
     }
@@ -164,10 +164,10 @@ impl<const PREFIX_LEN: usize> Header<PREFIX_LEN> {
             // we used the leaf to match the number of matching bytes,
             // by this we know that len < prefix len, but since we + 1,
             // to skip the key byte we have that len <= prefix len
-            std::hint::assert_unchecked(end <= leaf_key.len());
+            core::hint::assert_unchecked(end <= leaf_key.len());
 
             // SAFETY: This is by construction end = begin + len
-            std::hint::assert_unchecked(begin <= end);
+            core::hint::assert_unchecked(begin <= end);
         }
 
         let leaf_key = &leaf_key[begin..end];
@@ -206,14 +206,14 @@ impl<const PREFIX_LEN: usize> Header<PREFIX_LEN> {
                 // expect that the depth never exceeds the key len.
                 // Because if this happens we ran out of bytes in the key to match
                 // and the whole process should be already finished
-                std::hint::assert_unchecked(current_depth <= leaf.len());
+                core::hint::assert_unchecked(current_depth <= leaf.len());
 
                 // SAFETY: By the construction of the prefix we know that this is inbounds
                 // since the prefix len guarantees it to us
-                std::hint::assert_unchecked(current_depth + len <= leaf.len());
+                core::hint::assert_unchecked(current_depth + len <= leaf.len());
 
                 // SAFETY: This can't overflow since len comes from a u32
-                std::hint::assert_unchecked(current_depth <= current_depth + len);
+                core::hint::assert_unchecked(current_depth <= current_depth + len);
             }
             let leaf = &leaf[current_depth..(current_depth + len)];
             (leaf, Some(leaf_ptr))
@@ -232,7 +232,7 @@ pub type NodePrefix<'a, K, V, const PREFIX_LEN: usize> = (
 );
 
 impl<const PREFIX_LEN: usize> Debug for Header<PREFIX_LEN> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Header")
             .field("num_children", &self.num_children)
             .field("prefix_len", &self.prefix_len)

--- a/src/raw/visitor.rs
+++ b/src/raw/visitor.rs
@@ -1,7 +1,9 @@
 //! Utilities for inspecting the trie structure.
 
+#[cfg(feature = "std")]
 mod pretty_printer;
 mod tree_stats;
+#[cfg(feature = "std")]
 mod well_formed;
 
 use super::{
@@ -9,8 +11,10 @@ use super::{
     NodePtr, OpaqueNodePtr,
 };
 
+#[cfg(feature = "std")]
 pub use pretty_printer::*;
 pub use tree_stats::*;
+#[cfg(feature = "std")]
 pub use well_formed::*;
 
 /// The `Visitable` trait allows [`Visitor`]s to traverse the structure of the

--- a/src/raw/visitor/pretty_printer.rs
+++ b/src/raw/visitor/pretty_printer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     raw::{InnerNode, NodeType, OpaqueNodePtr},
     visitor::{Visitable, Visitor},
     AsBytes, TreeMap,
@@ -271,6 +271,7 @@ pub fn bytes_display_fmt(value: &impl AsBytes, f: &mut fmt::Formatter) -> fmt::R
 #[cfg(test)]
 mod tests {
     use crate::tests_common::swap;
+    use alloc::{string::String, vec::Vec};
 
     use super::*;
 

--- a/src/raw/visitor/well_formed.rs
+++ b/src/raw/visitor/well_formed.rs
@@ -1,18 +1,19 @@
 use crate::{
-    alloc::Allocator,
+    allocator::Allocator,
     raw::{
         visitor::{Visitable, Visitor},
         InnerNode, LeafNode, NodePtr, NodeType, OpaqueNodePtr, OptionalLeafPtr,
     },
     AsBytes, TreeMap,
 };
-use std::{
+use alloc::{boxed::Box, vec::Vec};
+use core::{
     cmp::Ordering,
-    collections::{hash_map::Entry, HashMap},
     error::Error,
     fmt,
     ops::{Add, AddAssign},
 };
+use std::collections::{hash_map::Entry, HashMap};
 
 /// A portion of an entire key that should uniquely identify each node in
 /// the tree.
@@ -624,11 +625,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CString;
+    use alloc::ffi::CString;
 
     use super::*;
     use crate::{
-        alloc::Global,
+        allocator::Global,
         raw::{InnerNode16, InnerNode4, LeafNode, NodePtr},
         tests_common::{generate_key_fixed_length, setup_tree_from_entries},
         TreeMap,

--- a/src/rust_nightly_apis.rs
+++ b/src/rust_nightly_apis.rs
@@ -10,7 +10,7 @@
 /// Calling this when the content is not yet fully initialized causes
 /// undefined behavior.
 ///
-/// See [`assume_init_ref`][std::mem::MaybeUninit::assume_init_ref] for more
+/// See [`assume_init_ref`][core::mem::MaybeUninit::assume_init_ref] for more
 /// details and examples.
 ///
 /// **This is a unstable API copied from the Rust standard library, tracking
@@ -19,7 +19,7 @@
 /// [issue-63569]: https://github.com/rust-lang/rust/issues/63569
 #[inline]
 pub const unsafe fn maybe_uninit_slice_assume_init_ref<T>(
-    slice: &[std::mem::MaybeUninit<T>],
+    slice: &[core::mem::MaybeUninit<T>],
 ) -> &[T] {
     #[cfg(feature = "nightly")]
     {
@@ -34,7 +34,7 @@ pub const unsafe fn maybe_uninit_slice_assume_init_ref<T>(
         // layout as `T`. The pointer obtained is valid since it refers to memory owned
         // by `slice` which is a reference and thus guaranteed to be valid for
         // reads.
-        unsafe { &*(slice as *const [std::mem::MaybeUninit<T>] as *const [T]) }
+        unsafe { &*(slice as *const [core::mem::MaybeUninit<T>] as *const [T]) }
     }
 }
 
@@ -47,7 +47,7 @@ pub const unsafe fn maybe_uninit_slice_assume_init_ref<T>(
 /// Calling this when the content is not yet fully initialized causes
 /// undefined behavior.
 ///
-/// See [`assume_init_mut`][std::mem::MaybeUninit::assume_init_mut] for more
+/// See [`assume_init_mut`][core::mem::MaybeUninit::assume_init_mut] for more
 /// details and examples.
 ///
 /// **This is a unstable API copied from the Rust standard library, tracking
@@ -56,7 +56,7 @@ pub const unsafe fn maybe_uninit_slice_assume_init_ref<T>(
 /// [issue-63569]: https://github.com/rust-lang/rust/issues/63569
 #[inline]
 pub unsafe fn maybe_uninit_slice_assume_init_mut<T>(
-    slice: &mut [std::mem::MaybeUninit<T>],
+    slice: &mut [core::mem::MaybeUninit<T>],
 ) -> &mut [T] {
     #[cfg(feature = "nightly")]
     {
@@ -69,7 +69,7 @@ pub unsafe fn maybe_uninit_slice_assume_init_mut<T>(
         // SAFETY: similar to safety notes for `maybe_uninit_slice_assume_init_ref`, but
         // we have a mutable reference which is also guaranteed to be valid for
         // writes.
-        unsafe { &mut *(slice as *mut [std::mem::MaybeUninit<T>] as *mut [T]) }
+        unsafe { &mut *(slice as *mut [core::mem::MaybeUninit<T>] as *mut [T]) }
     }
 }
 
@@ -87,7 +87,7 @@ pub unsafe fn maybe_uninit_slice_assume_init_mut<T>(
 ///
 /// This method is only for providing domain separation.  If you want to
 /// hash a `usize` that represents part of the *data*, then it's important
-/// that you pass it to [`Hasher::write_usize`][std::hash::Hasher::write_usize]
+/// that you pass it to [`Hasher::write_usize`][core::hash::Hasher::write_usize]
 /// instead of to this method.
 ///
 /// # Note to Implementers
@@ -101,10 +101,10 @@ pub unsafe fn maybe_uninit_slice_assume_init_mut<T>(
 ///
 /// [issue-96762]: https://github.com/rust-lang/rust/issues/96762
 #[inline]
-pub fn hasher_write_length_prefix<H: std::hash::Hasher>(state: &mut H, num_entries: usize) {
+pub fn hasher_write_length_prefix<H: core::hash::Hasher>(state: &mut H, num_entries: usize) {
     #[cfg(feature = "nightly")]
     {
-        <H as std::hash::Hasher>::write_length_prefix(state, num_entries);
+        <H as core::hash::Hasher>::write_length_prefix(state, num_entries);
     }
 
     #[cfg(not(feature = "nightly"))]
@@ -126,7 +126,7 @@ pub fn hasher_write_length_prefix<H: std::hash::Hasher>(state: &mut H, num_entri
 #[cfg(feature = "nightly")]
 macro_rules! likely {
     ($b:expr) => {
-        std::hint::likely($b)
+        core::hint::likely($b)
     };
 }
 
@@ -163,7 +163,7 @@ pub(crate) use likely;
 #[cfg(feature = "nightly")]
 macro_rules! unlikely {
     ($b:expr) => {
-        std::hint::unlikely($b)
+        core::hint::unlikely($b)
     };
 }
 
@@ -191,7 +191,7 @@ pub(crate) mod ptr {
     //! This module contains shim functions for strict-provenance stuff related
     //! to pointers
 
-    use std::{num::NonZeroUsize, ptr::NonNull};
+    use core::{num::NonZeroUsize, ptr::NonNull};
 
     #[inline]
     #[cfg(not(feature = "nightly"))]
@@ -200,7 +200,7 @@ pub(crate) mod ptr {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler
         // intrinsic. SAFETY: Pointer-to-integer transmutes are valid (if you
         // are okay with losing the provenance).
-        unsafe { std::mem::transmute(ptr.cast::<()>()) }
+        unsafe { core::mem::transmute(ptr.cast::<()>()) }
     }
 
     #[inline]

--- a/src/tagged_pointer.rs
+++ b/src/tagged_pointer.rs
@@ -8,7 +8,7 @@
 //! pointed-to type, so that it can store several bits of information. For a
 //! type with alignment `A`, the number of available bits is `log_2(A)`.
 
-use std::{fmt, mem::align_of, num::NonZeroUsize, ptr::NonNull};
+use core::{fmt, mem::align_of, num::NonZeroUsize, ptr::NonNull};
 
 use crate::rust_nightly_apis::ptr;
 
@@ -184,20 +184,20 @@ impl<P, const MIN_BITS: u32> From<&mut P> for TaggedPointer<P, MIN_BITS> {
     }
 }
 
-impl<P, const MIN_BITS: u32> std::hash::Hash for TaggedPointer<P, MIN_BITS> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl<P, const MIN_BITS: u32> core::hash::Hash for TaggedPointer<P, MIN_BITS> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
 
 impl<P, const MIN_BITS: u32> Ord for TaggedPointer<P, MIN_BITS> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.0.cmp(&other.0)
     }
 }
 
 impl<P, const MIN_BITS: u32> PartialOrd for TaggedPointer<P, MIN_BITS> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -236,6 +236,7 @@ impl<P, const MIN_BITS: u32> fmt::Pointer for TaggedPointer<P, MIN_BITS> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::boxed::Box;
 
     #[test]
     fn successful_tag() {
@@ -429,13 +430,17 @@ mod tests {
             0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000_usize
         );
 
+        #[cfg(feature = "std")]
+        let arch = std::env::consts::ARCH;
+        #[cfg(not(feature = "std"))]
+        let arch = "no_std";
+
         // Something weird about the representation of u128 on intel architectures:
         // https://github.com/rust-lang/rust/issues/54341 - This was fixed in 1.77
         assert_eq!(
             TaggedPointer::<u128, 5>::ALIGNMENT,
             16,
-            "Target architecture [{}]",
-            std::env::consts::ARCH
+            "Target architecture [{arch}]",
         );
         assert_eq!(TaggedPointer::<u128, 3>::NUM_BITS, 4);
 

--- a/src/tests_common.rs
+++ b/src/tests_common.rs
@@ -1,10 +1,11 @@
 //! Helper function for writing tests
 
-use std::{collections::HashSet, iter};
+use alloc::boxed::Box;
+use core::iter;
 
 #[cfg(test)]
 use crate::{
-    alloc::Global,
+    allocator::Global,
     raw::{InsertPrefixError, InsertResult, OpaqueNodePtr},
     AsBytes, TreeMap,
 };
@@ -302,8 +303,9 @@ pub fn generate_key_with_prefix<const KEY_LENGTH: usize>(
             .all(|expand| { expand.expanded_length > 0 }),
         "the prefix expansion length must be greater than 0."
     );
+    #[cfg(feature = "std")]
     {
-        let mut uniq_indices = HashSet::new();
+        let mut uniq_indices = std::collections::HashSet::new();
         assert!(
             expansions
                 .iter()


### PR DESCRIPTION
Adds a `std` feature flag that is enabled by default.

Some unit tests are now behind the `std` feature flag because they require either `HashMap`, `HashSet` or a hasher, none of which are available without std or extra dependencies.
New `unchecked_from_raw` associated methods have been added to `TreeMap` since the `from_raw` methods are checked using the well formed tree checker which requires std (because it requires hash maps).

Testing if blart builds on a platform without std when default features are turned off in the ci should be done to ensure we don't accidentally include std.
I'll try looking around to see if someone else has done this before using the github ci (presumably someone has).

Closes: #55.