### PR TITLE
Fix prefix iter regression

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # 1.82 is the MSRV for the crate
-        rust: ['nightly', 'beta', 'stable', '1.82']
+        # 1.85 is the MSRV for the crate
+        rust: ['nightly', 'beta', 'stable', '1.85']
 
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
  - `TreeMap::{get_prefix, get_prefix_key_value, get_prefix_mut, force_insert}` were renamed to `TreeMap::{prefix_get, prefix_get_key_value, prefix_get_mut, prefix_insert}`. This makes it clear that they're all centered around the theme of manipulating or querying key prefixes.
+ - Update MSRV to 1.85
 
 ## [0.4.0] - 2025-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - `TreeMap::{get_prefix, get_prefix_key_value, get_prefix_mut, force_insert}` were renamed to `TreeMap::{prefix_get, prefix_get_key_value, prefix_get_mut, prefix_insert}`. This makes it clear that they're all centered around the theme of manipulating or querying key prefixes.
  - Update MSRV to 1.85
 
+### Fixed
+
+ - `TreeMap::prefix` iterator was broken (see [issue 66]) because a refactor stopped distinguishing between different cases of inner nodes matching or not matching the prefix.
+
+[issue 66]: https://github.com/declanvk/blart/issues/66
+
 ## [0.4.0] - 2025-07-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["tree", "map", "collection", "radix-tree"]
 categories = ["data-structures"]
 # MSRV
-rust-version = "1.82"
+rust-version = "1.85"
 
 exclude = [
     "fuzz/",

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -351,7 +351,7 @@ assert!(matches!(map.allocator(), &System));
         //
         // Also this is safe from a double-free since we're using `ManuallyDrop` to
         // inhibit the first copy of `A` (in the `tree` value) from doing anything.
-        let alloc = unsafe { ptr::read(&tree.alloc) };
+        let alloc = unsafe { ptr::read(&raw const tree.alloc) };
         let root = tree.state.as_ref().map(|state| state.root);
 
         (root, alloc)
@@ -1875,13 +1875,14 @@ impl<K, V, const PREFIX_LEN: usize, A: Allocator> TreeMap<K, V, PREFIX_LEN, A> {
     /// Tries to get the given key’s corresponding prefix entry in the map for
     /// in-place manipulation.
     ///
-    /// This entry represents an unfinished [prefix_insert](Self::prefix_insert)
-    /// operation. Compared to [Entry], it has one extra occupied state
-    /// called [InnerOccupiedEntry]. This entry represents the
+    /// This entry represents an unfinished
+    /// [`prefix_insert`](Self::prefix_insert) operation. Compared to
+    /// [`Entry`], it has one extra occupied state
+    /// called [`InnerOccupiedEntry`]. This entry represents the
     /// `prefix_insert` case were the exact key was not found, but a prefix
     /// of the given key or vice versa was found.
     ///
-    /// See also: [Self::try_entry].
+    /// See also: [`Self::try_entry`].
     ///
     /// # Examples
     ///

--- a/src/collections/map/entry.rs
+++ b/src/collections/map/entry.rs
@@ -320,7 +320,7 @@ where
     /// the key that was moved during the .entry(key) method call.
     ///
     /// The reference to the moved key is provided so that cloning or copying
-    /// the key is unnecessary, unlike with .or_insert_with(|| ... ).
+    /// the key is unnecessary, unlike with `.or_insert_with(|| ... )`.
     pub fn or_insert_with_key<F>(self, f: F) -> &'a mut V
     where
         F: FnOnce(&K) -> V,

--- a/src/collections/map/iterators/extract_if.rs
+++ b/src/collections/map/iterators/extract_if.rs
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<'a, K, V, F, const PREFIX_LEN: usize, A> Iterator for ExtractIf<'a, K, V, F, PREFIX_LEN, A>
+impl<K, V, F, const PREFIX_LEN: usize, A> Iterator for ExtractIf<'_, K, V, F, PREFIX_LEN, A>
 where
     K: AsBytes,
     F: FnMut(&K, &mut V) -> bool,
@@ -171,8 +171,8 @@ where
     }
 }
 
-impl<'a, K, V, F, const PREFIX_LEN: usize, A> DoubleEndedIterator
-    for ExtractIf<'a, K, V, F, PREFIX_LEN, A>
+impl<K, V, F, const PREFIX_LEN: usize, A> DoubleEndedIterator
+    for ExtractIf<'_, K, V, F, PREFIX_LEN, A>
 where
     K: AsBytes,
     F: FnMut(&K, &mut V) -> bool,

--- a/src/collections/map/iterators/fuzzy.rs
+++ b/src/collections/map/iterators/fuzzy.rs
@@ -114,8 +114,8 @@ pub(crate) fn edit_dist(
         unsafe {
             let b = *key.get_unchecked(i - 1) == c;
 
-            let k1 = b as usize;
-            let k2 = !b as usize;
+            let k1: usize = b.into();
+            let k2: usize = (!b).into();
 
             let substitution = *old.get_unchecked(i - 1);
             let insertion = *old.get_unchecked(i);

--- a/src/collections/map/iterators/into_iter.rs
+++ b/src/collections/map/iterators/into_iter.rs
@@ -57,7 +57,7 @@ impl<K, V, const PREFIX_LEN: usize, A: Allocator> Drop for IntoIter<K, V, PREFIX
             deallocate_leaves(
                 mem::replace(&mut self.inner, RawIterator::empty()),
                 &self.alloc,
-            )
+            );
         }
 
         // Just to be safe, clear the iterator size
@@ -76,7 +76,7 @@ impl<K, V, const PREFIX_LEN: usize, A: Allocator> IntoIter<K, V, PREFIX_LEN, A> 
         //
         // Also this is safe from a double-free since we're using `ManuallyDrop` to
         // inhibit the first copy of `A` (in the `tree` value) from doing anything.
-        let alloc = unsafe { ptr::read(&tree.alloc) };
+        let alloc = unsafe { ptr::read(&raw const tree.alloc) };
 
         if let Some(state) = &tree.state {
             // SAFETY: By construction (and maintained on insert/delete), the `min_leaf` is

--- a/src/collections/map/iterators/prefix.rs
+++ b/src/collections/map/iterators/prefix.rs
@@ -316,4 +316,141 @@ mod tests {
             vec![(c"abcde", 0), (c"abcdx", 100), (c"abcx", 100), (c"bx", 0)]
         )
     }
+
+    #[test]
+    fn prefix_mut_rev() {
+        let mut t = TreeMap::new();
+        t.insert(c"abcde", 1);
+        t.insert(c"abcdexxx", 2);
+        t.insert(c"abcdexxy", 3);
+        t.insert(c"bx", 4);
+
+        let result: Vec<_> = t.prefix_mut(c"abcde".to_bytes()).rev().collect();
+        assert_eq!(
+            result,
+            vec![
+                (&c"abcdexxy", &mut 3),
+                (&c"abcdexxx", &mut 2),
+                (&c"abcde", &mut 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn prefix_interleaved_forward_and_backward() {
+        let mut t = TreeMap::new();
+        t.insert(c"abcde", 0);
+        t.insert(c"abcdexxx", 1);
+        t.insert(c"abcdexxy", 2);
+        t.insert(c"abcdexyz", 3);
+
+        let mut it = t.prefix(c"abcde".to_bytes());
+        assert_eq!(it.next(), Some((&c"abcde", &0)));
+        assert_eq!(it.next_back(), Some((&c"abcdexyz", &3)));
+        assert_eq!(it.next(), Some((&c"abcdexxx", &1)));
+        assert_eq!(it.next_back(), Some((&c"abcdexxy", &2)));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn prefix_fused_after_exhaustion() {
+        let mut t = TreeMap::new();
+        t.insert(c"abc", 0);
+
+        let mut it = t.prefix(c"abc".to_bytes());
+        assert_eq!(it.next(), Some((&c"abc", &0)));
+        assert_eq!(it.next(), None);
+        // fused: must keep returning None
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn prefix_longer_than_all_keys_returns_empty() {
+        let mut t = TreeMap::new();
+        t.insert(c"ab", 0);
+        t.insert(c"abc", 1);
+
+        // Searching for a prefix longer than any existing key
+        assert_eq!(t.prefix(b"abcdefgh").count(), 0);
+    }
+
+    #[test]
+    fn prefix_key_is_also_a_prefix_of_other_keys() {
+        // "abcde" is both a key and a prefix of "abcdexxx"
+        let mut t = TreeMap::new();
+        t.insert(c"abcde", 0);
+        t.insert(c"abcdexxx", 1);
+        t.insert(c"abcx", 2);
+
+        let p: Vec<_> = t.prefix(c"abcde".to_bytes()).collect();
+        assert_eq!(p, vec![(&c"abcde", &0), (&c"abcdexxx", &1)]);
+    }
+
+    #[test]
+    fn prefix_single_matching_key() {
+        let mut t = TreeMap::new();
+        t.insert([1u8, 2u8, 3u8], 42);
+
+        assert_eq!(t.prefix(&[1u8, 2u8, 3u8]).count(), 1);
+        assert_eq!(t.prefix(&[1u8, 2u8]).count(), 1);
+        assert_eq!(t.prefix(&[1u8]).count(), 1);
+        assert_eq!(t.prefix(&[2u8]).count(), 0);
+    }
+
+    #[test]
+    fn prefix_multiple_disjoint_subtrees() {
+        // Keys share no common prefix; each subtree should be isolated
+        let mut t = TreeMap::new();
+        t.insert(c"aaa", 0);
+        t.insert(c"aab", 1);
+        t.insert(c"baa", 2);
+        t.insert(c"bab", 3);
+
+        let pa: Vec<_> = t.prefix(c"a".to_bytes()).collect();
+        assert_eq!(pa, vec![(&c"aaa", &0), (&c"aab", &1)]);
+
+        let pb: Vec<_> = t.prefix(c"b".to_bytes()).collect();
+        assert_eq!(pb, vec![(&c"baa", &2), (&c"bab", &3)]);
+    }
+
+    #[test]
+    fn prefix_full_key_bytes_no_nul_terminator() {
+        // Use raw byte arrays so there is no implicit NUL; the prefix is the
+        // full key, ensuring the leaf-check path in the iterator is exercised.
+        let mut t = TreeMap::<[u8; 3], i32>::new();
+        t.insert([0u8, 0u8, 1u8], 1);
+        t.insert([0u8, 0u8, 2u8], 2);
+        t.insert([0u8, 1u8, 0u8], 3);
+
+        let p: Vec<_> = t.prefix(&[0u8, 0u8]).collect();
+        assert_eq!(p, vec![(&[0u8, 0u8, 1u8], &1), (&[0u8, 0u8, 2u8], &2)]);
+
+        // Prefix that matches exactly one leaf
+        let p: Vec<_> = t.prefix(&[0u8, 0u8, 1u8]).collect();
+        assert_eq!(p, vec![(&[0u8, 0u8, 1u8], &1)]);
+    }
+
+    /// Regression test for https://github.com/declanvk/blart/issues/66
+    ///
+    /// The prefix iterator should return an empty iterator when no keys match
+    /// the prefix. In blart 0.3.0 and 0.4.0 it incorrectly returns both
+    /// keys.
+    #[test]
+    #[should_panic(expected = "`left == right` failed")]
+    fn test_prefix_iterator_no_false_matches() {
+        // Construct a map with the following keys
+        // [0, 0]
+        // [0, 1]
+        let mut map = TreeMap::<[u8; 2], ()>::new();
+        map.insert(0u16.to_be_bytes(), ());
+        map.insert(1u16.to_be_bytes(), ());
+
+        // Search for entries with prefix [1, 0]
+        let prefix: &[u8] = &256u16.to_be_bytes();
+
+        // There should be no results here
+        assert_eq!(0, map.prefix(prefix).count());
+    }
 }

--- a/src/collections/map/iterators/prefix.rs
+++ b/src/collections/map/iterators/prefix.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     allocator::{Allocator, Global},
-    map::DEFAULT_PREFIX_LEN,
+    map::{NonEmptyTree, DEFAULT_PREFIX_LEN},
     raw::{maximum_unchecked, minimum_unchecked, RawIterator},
     AsBytes, TreeMap,
 };
@@ -40,48 +40,11 @@ macro_rules! implement_prefix_iter {
                     };
                 };
 
-                // SAFETY: Since we have a (shared or mutable) reference to the original
-                // TreeMap, we know there will be no concurrent mutation
-                let search_result = unsafe { find_terminating_node(tree_state.root, prefix) };
-                let (start, end) = match search_result {
-                    TerminatingNodeSearchResult::Leaf { leaf_ptr, .. } => {
-                        // SAFETY: Its safe to create a shared reference to the leaf since we hold
-                        // either a shared or mutable reference to the owning TreeMap, which prevents
-                        // other concurrent mutable references.
-                        let leaf = unsafe { leaf_ptr.as_ref() };
-
-                        // Only include the item in the iterator if the prefix actually matches
-                        if leaf.key_ref().as_bytes().starts_with(prefix) {
-                            (leaf_ptr, leaf_ptr)
-                        } else {
-                            return Self {
-                                _tree: tree,
-                                inner: RawIterator::empty(),
-                            };
-                        }
-                    },
-                    TerminatingNodeSearchResult::InnerNode(InnerNodeSearchResult { node_ptr, reason, .. }) => {
-                        if matches!(reason, InnerNodeSearchResultReason::MissingChild) {
-                            // if the child is missing, then there is nothing to be the prefix of
-                            return Self {
-                                _tree: tree,
-                                inner: RawIterator::empty(),
-                            };
-                        }
-
-                        // SAFETY: Its safe to create a shared reference to the leaf since we hold
-                        // either a shared or mutable reference to the owning TreeMap, which prevents
-                        // other concurrent mutable references.
-                        unsafe { (minimum_unchecked(node_ptr), maximum_unchecked(node_ptr)) }
-                    },
-                };
+                let inner = prefix_iter_constructor(tree_state, prefix);
 
                 Self {
                     _tree: tree,
-                    // SAFETY: `start` is guaranteed to be less than or equal to `end` in the iteration
-                    // order because of the check we do on the bytes of the resolved leaf pointers, just
-                    // above this line
-                    inner: unsafe { RawIterator::new(start, end) },
+                    inner,
                 }
             }
         }
@@ -118,6 +81,53 @@ macro_rules! implement_prefix_iter {
 
         impl<'a, K, V, const PREFIX_LEN: usize, A: Allocator> FusedIterator for $name<'a, K, V, PREFIX_LEN, A> {}
     };
+}
+
+fn prefix_iter_constructor<K: AsBytes, V, const PREFIX_LEN: usize>(
+    tree_state: &NonEmptyTree<K, V, PREFIX_LEN>,
+    prefix: &[u8],
+) -> RawIterator<K, V, PREFIX_LEN> {
+    // SAFETY: Since we have a (shared or mutable) reference to the original
+    // TreeMap, we know there will be no concurrent mutation
+    let search_result = unsafe { find_terminating_node(tree_state.root, prefix) };
+    let (start, end) = match search_result {
+        TerminatingNodeSearchResult::Leaf { leaf_ptr, .. } => {
+            // SAFETY: Its safe to create a shared reference to the leaf since we hold
+            // either a shared or mutable reference to the owning TreeMap, which prevents
+            // other concurrent mutable references.
+            let leaf = unsafe { leaf_ptr.as_ref() };
+
+            // Only include the item in the iterator if the prefix actually matches
+            if leaf.key_ref().as_bytes().starts_with(prefix) {
+                (leaf_ptr, leaf_ptr)
+            } else {
+                return RawIterator::empty();
+            }
+        },
+        TerminatingNodeSearchResult::InnerNode(InnerNodeSearchResult {
+            node_ptr, reason, ..
+        }) => {
+            match reason {
+                InnerNodeSearchResultReason::PrefixMismatch
+                | InnerNodeSearchResultReason::MissingChild => {
+                    // if the child is missing OR there is a prefix mismatch, then there is nothing
+                    // to be the prefix of
+                    return RawIterator::empty();
+                },
+                InnerNodeSearchResultReason::InsufficientBytes => {
+                    // SAFETY: Its safe to create a shared reference to the leaf since we hold
+                    // either a shared or mutable reference to the owning TreeMap, which prevents
+                    // other concurrent mutable references.
+                    unsafe { (minimum_unchecked(node_ptr), maximum_unchecked(node_ptr)) }
+                },
+            }
+        },
+    };
+
+    // SAFETY: `start` is guaranteed to be less than or equal to `end` in the
+    // iteration order because of the check we do on the bytes of the resolved
+    // leaf pointers, just above this line
+    unsafe { RawIterator::new(start, end) }
 }
 
 implement_prefix_iter!(
@@ -438,8 +448,7 @@ mod tests {
     /// the prefix. In blart 0.3.0 and 0.4.0 it incorrectly returns both
     /// keys.
     #[test]
-    #[should_panic(expected = "`left == right` failed")]
-    fn test_prefix_iterator_no_false_matches() {
+    fn prefix_iterator_no_false_matches() {
         // Construct a map with the following keys
         // [0, 0]
         // [0, 1]

--- a/src/collections/map/iterators/range.rs
+++ b/src/collections/map/iterators/range.rs
@@ -14,7 +14,7 @@ use crate::{
     raw::{
         match_concrete_node_ptr, maximum_unchecked, minimum_unchecked,
         AttemptOptimisticPrefixMatch, ConcreteNodePtr, InnerNode, LeafNode, NodePtr, OpaqueNodePtr,
-        PrefixMatchBehavior, RawIterator,
+        PessimisticMismatch, PrefixMatchBehavior, RawIterator,
     },
     AsBytes, TreeMap,
 };
@@ -55,9 +55,11 @@ impl<K, V, const PREFIX_LEN: usize> fmt::Debug for InnerNodeSearchResult<K, V, P
 #[derive(Debug)]
 pub(crate) enum InnerNodeSearchResultReason {
     /// This variant means the search terminated in a mismatched prefix of an
-    /// inner node OR the prefix matched, but there were insufficient key bytes
-    /// to lookup a child of the inner node.
-    PrefixMismatchOrInsufficientBytes,
+    /// inner node.
+    PrefixMismatch,
+    /// This variant means the search terminated because the key was too short,
+    /// not because of a mismatch with prefix or child key byte.
+    InsufficientBytes,
     /// This variant means the search terminated in an inner node, when there
     /// was no corresponding child for a key byte.
     MissingChild,
@@ -136,17 +138,34 @@ pub(crate) unsafe fn find_terminating_node<K: AsBytes, V, const PREFIX_LEN: usiz
         let match_prefix =
             prefix_match_behavior.match_prefix(inner_node, &key_bytes[*current_depth..]);
         match match_prefix {
-            Err(_) => {
+            Err(PessimisticMismatch { matched_bytes, .. }) => {
                 let (full_prefix, _) = inner_node.read_full_prefix(*current_depth);
                 let upper_bound = (*current_depth + full_prefix.len()).min(key_bytes.len());
                 let key_segment = &key_bytes[(*current_depth)..upper_bound];
 
                 let node_prefix_comparison_to_search_key_segment = full_prefix.cmp(key_segment);
 
+                debug_assert_ne!(
+                    node_prefix_comparison_to_search_key_segment,
+                    Ordering::Equal,
+                    "if there was a mismatch, the prefix must not be equal"
+                );
+
+                // We report a prefix mismatch if the prefix is longer that the remaining
+                // portion of the key bytes. However, in the context of the
+                // `InnerNodeSearchResultReason` running out of bytes is really a different
+                // thing than a mismatch. We should only report mismatch as the reason if there
+                // was an actual byte difference.
+                let reason = if matched_bytes == key_bytes[*current_depth..].len() {
+                    InnerNodeSearchResultReason::InsufficientBytes
+                } else {
+                    InnerNodeSearchResultReason::PrefixMismatch
+                };
+
                 ControlFlow::Break(InnerNodeSearchResult {
                     node_ptr: inner_ptr.to_opaque(),
                     current_depth: *current_depth,
-                    reason: InnerNodeSearchResultReason::PrefixMismatchOrInsufficientBytes,
+                    reason,
                     node_prefix_comparison_to_search_key_segment,
                 })
             },
@@ -163,7 +182,7 @@ pub(crate) unsafe fn find_terminating_node<K: AsBytes, V, const PREFIX_LEN: usiz
                     return ControlFlow::Break(InnerNodeSearchResult {
                         node_ptr: inner_ptr.to_opaque(),
                         current_depth: *current_depth,
-                        reason: InnerNodeSearchResultReason::PrefixMismatchOrInsufficientBytes,
+                        reason: InnerNodeSearchResultReason::InsufficientBytes,
                         node_prefix_comparison_to_search_key_segment: Ordering::Equal,
                     });
                 };
@@ -308,7 +327,8 @@ pub(crate) unsafe fn find_leaf_pointer_for_bound<K: AsBytes, V, const PREFIX_LEN
                     reason,
                     node_prefix_comparison_to_search_key_segment,
                 }) => match reason {
-                    InnerNodeSearchResultReason::PrefixMismatchOrInsufficientBytes => {
+                    InnerNodeSearchResultReason::PrefixMismatch
+                    | InnerNodeSearchResultReason::InsufficientBytes => {
                         match (is_start, node_prefix_comparison_to_search_key_segment) {
                             (true, Ordering::Equal | Ordering::Greater) => unsafe {
                                 // SAFETY: Covered by function safety doc

--- a/src/collections/map/prefix_entry.rs
+++ b/src/collections/map/prefix_entry.rs
@@ -112,7 +112,7 @@ where
     /// Erase the subtree and insert the value with the previously given key in
     /// its place.
     ///
-    /// Returns an [OccupiedEntry].
+    /// Returns an [`OccupiedEntry`].
     pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, PREFIX_LEN, A> {
         // no fixup required since an overwrite never changes the parent node.
         let path = self.overwrite_point.path;
@@ -189,7 +189,7 @@ where
 
     /// Sets the value of the entry.
     ///
-    /// Returns an [OccupiedEntry].
+    /// Returns an [`OccupiedEntry`].
     pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, PREFIX_LEN, A> {
         match self {
             Self::Leaf(mut leaf) => {

--- a/src/raw/representation.rs
+++ b/src/raw/representation.rs
@@ -273,6 +273,10 @@ pub unsafe trait InnerNodeCommon<K, V, const PREFIX_LEN: usize>: Sized {
     /// the key. The caller who uses this function must perform a final check
     /// against the leaf key bytes to make sure that the search key matches the
     /// found key.
+    ///
+    /// # Errors
+    /// This function returns an error if there is a mismatch between the
+    /// partial stored prefix and the given truncated key.
     #[inline]
     fn optimistic_match_prefix(
         &self,
@@ -307,6 +311,10 @@ pub unsafe trait InnerNodeCommon<K, V, const PREFIX_LEN: usize>: Sized {
     /// reaches a leaf node using these results, then the caller must perform a
     /// final check against the leaf key bytes to make sure that the search
     /// key matches the found key.
+    ///
+    /// # Errors
+    /// This function returns an error if there is a mismatch between the given
+    /// truncated key and the stored (implicit or full) prefix.
     #[inline]
     fn attempt_pessimistic_match_prefix(
         &self,
@@ -351,6 +359,10 @@ pub unsafe trait InnerNodeCommon<K, V, const PREFIX_LEN: usize>: Sized {
     ///
     /// # Safety
     /// `current_depth` must be less than or equal to `key.len()`
+    ///
+    /// # Errors
+    /// This function returns an error if there is a mismatch between the
+    /// provided key and the full prefix.
     #[inline]
     unsafe fn match_full_prefix(
         &self,

--- a/src/raw/representation/inner_node_indirect.rs
+++ b/src/raw/representation/inner_node_indirect.rs
@@ -35,7 +35,7 @@ pub struct InnerNodeIndirect<K, V, const PREFIX_LEN: usize, const SIZE: usize> {
     /// the `child_pointers` array.
     ///
     /// All the `child_indices` values are guaranteed to be
-    /// `PartialNodeIndex<48>::EMPTY` when the node is constructed.
+    /// `None` when the node is constructed.
     pub child_indices: [Option<NonMaxIndex>; 256],
 }
 

--- a/src/raw/representation/inner_node_indirect/index.rs
+++ b/src/raw/representation/inner_node_indirect/index.rs
@@ -98,7 +98,7 @@ impl PartialOrd for NonMaxIndex {
 }
 
 /// The error type returned when attempting to construct an index outside
-/// the accepted range of a PartialNodeIndex.
+/// the accepted range of a [`NonMaxIndex`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TryFromByteError(());
 

--- a/src/raw/representation/pointers.rs
+++ b/src/raw/representation/pointers.rs
@@ -26,7 +26,7 @@ pub(super) struct OpaqueValue;
 
 /// An opaque pointer to a [`Node`].
 ///
-/// Could be any one of the NodeTypes, need to perform check on the runtime
+/// Could be any one of the [`NodeType`]s, need to perform check on the runtime
 /// type and then cast to a [`NodePtr`].
 #[repr(transparent)]
 pub struct OpaqueNodePtr<K, V, const PREFIX_LEN: usize>(
@@ -348,6 +348,10 @@ impl<const PREFIX_LEN: usize, N: Node<PREFIX_LEN>> NodePtr<PREFIX_LEN, N> {
 
     /// Allocate the given [`Node`] on the [`alloc::alloc::Global`] heap and
     /// return a [`NodePtr`] that wrap the raw pointer.
+    ///
+    /// # Panics
+    /// This function will panic if the underlying allocate function returns an
+    /// error.
     pub fn allocate_node_ptr(node: N, alloc: &impl Allocator) -> Self {
         let layout = Layout::new::<mem::MaybeUninit<N>>();
         let mut ptr: NonNull<mem::MaybeUninit<N>> =
@@ -435,7 +439,7 @@ impl<const PREFIX_LEN: usize, N: Node<PREFIX_LEN>> NodePtr<PREFIX_LEN, N> {
     ///    'a is arbitrarily chosen and does not necessarily reflect the actual
     ///    lifetime of the data. In particular, for the duration of this
     ///    lifetime, the memory the pointer points to must not get mutated
-    ///    (except inside UnsafeCell).
+    ///    (except inside `UnsafeCell`).
     pub unsafe fn as_ref<'a>(self) -> &'a N {
         // SAFETY: The pointer is properly aligned and points to a initialized instance
         // of N that is dereferenceable. The lifetime safety requirements are passed up
@@ -473,7 +477,7 @@ impl<K, V, const PREFIX_LEN: usize> NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LE
     ///    'a is arbitrarily chosen and does not necessarily reflect the actual
     ///    lifetime of the data. In particular, for the duration of this
     ///    lifetime, the memory the pointer points to must not get mutated
-    ///    (except inside UnsafeCell).
+    ///    (except inside `UnsafeCell`).
     pub unsafe fn as_key_value_ref<'a>(self) -> (&'a K, &'a V) {
         // SAFETY: Safety requirements are covered by the containing function.
         let leaf = unsafe { self.as_ref() };
@@ -506,7 +510,7 @@ impl<K, V, const PREFIX_LEN: usize> NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LE
     ///    'a is arbitrarily chosen and does not necessarily reflect the actual
     ///    lifetime of the data. In particular, for the duration of this
     ///    lifetime, the memory the pointer points to must not get mutated
-    ///    (except inside UnsafeCell).
+    ///    (except inside `UnsafeCell`).
     pub unsafe fn as_key_ref<'a>(self) -> &'a K
     where
         V: 'a,
@@ -525,7 +529,7 @@ impl<K, V, const PREFIX_LEN: usize> NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LE
     ///    'a is arbitrarily chosen and does not necessarily reflect the actual
     ///    lifetime of the data. In particular, for the duration of this
     ///    lifetime, the memory the pointer points to must not get mutated
-    ///    (except inside UnsafeCell).
+    ///    (except inside `UnsafeCell`).
     pub unsafe fn as_value_ref<'a>(self) -> &'a V
     where
         K: 'a,
@@ -569,7 +573,7 @@ impl<const PREFIX_LEN: usize, N: Node<PREFIX_LEN>> From<&mut N> for NodePtr<PREF
     fn from(node_ref: &mut N) -> Self {
         // SAFETY: Pointer is non-null, aligned, and pointing to a valid instance of N
         // because it was constructed from a mutable reference.
-        unsafe { NodePtr::new(node_ref as *mut _) }
+        unsafe { NodePtr::new(ptr::from_mut(node_ref)) }
     }
 }
 

--- a/src/raw/visitor/pretty_printer.rs
+++ b/src/raw/visitor/pretty_printer.rs
@@ -1,11 +1,12 @@
 use std::{
-    fmt::{self},
+    fmt,
     io::{self, Write},
+    ptr,
 };
 
 use crate::{
     allocator::Allocator,
-    raw::{InnerNode, NodeType, OpaqueNodePtr},
+    raw::{InnerNode, NodePtr, NodeType, OpaqueNodePtr},
     visitor::{Visitable, Visitor},
     AsBytes, TreeMap,
 };
@@ -119,7 +120,7 @@ impl<O: Write, K, V> DotPrinter<O, K, V> {
             write!(
                 self.output,
                 "{{<h0> {:p}}}  | {{{:?} | {:?} | {:?}}} | {{",
-                inner_node as *const _,
+                ptr::from_ref(inner_node),
                 N::TYPE,
                 header.prefix_len(),
                 header.read_prefix()
@@ -200,13 +201,12 @@ where
             writeln!(
                 self.output,
                 "{{<h0> {:p}}} | {{{:?}}} | {{{}}} | {{{}}} | {{{:p} {:p}}} }}\"]",
-                t as *const _,
+                ptr::from_ref(t),
                 NodeType::Leaf,
                 key,
                 value,
-                t.previous
-                    .map_or(std::ptr::null_mut(), |prev| prev.to_ptr()),
-                t.next.map_or(std::ptr::null_mut(), |next| next.to_ptr()),
+                t.previous.map_or(ptr::null_mut(), NodePtr::to_ptr),
+                t.next.map_or(ptr::null_mut(), NodePtr::to_ptr),
             )?;
         } else {
             writeln!(
@@ -239,6 +239,11 @@ impl<T> fmt::Display for OverrideDisplay<'_, T> {
 /// This function can be used to override the formatting of key or value types
 /// when printing with [`DotPrinter`].
 ///
+/// # Errors
+///
+/// This function returns an error if the provided [`fmt::Formatter`] returns
+/// `Err`.
+///
 /// [`Debug::fmt`]: std::fmt::Debug::fmt
 pub fn debug_as_display_fmt(value: &impl fmt::Debug, f: &mut fmt::Formatter) -> fmt::Result {
     value.fmt(f)
@@ -248,6 +253,11 @@ pub fn debug_as_display_fmt(value: &impl fmt::Debug, f: &mut fmt::Formatter) -> 
 ///
 /// This function can be used to override the formatting of key or value types
 /// when printing with [`DotPrinter`].
+///
+/// # Errors
+///
+/// This function returns an error if the provided [`fmt::Formatter`] returns
+/// `Err`.
 pub fn null_display_fmt(_value: &impl fmt::Debug, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "[null]")
 }
@@ -256,6 +266,11 @@ pub fn null_display_fmt(_value: &impl fmt::Debug, f: &mut fmt::Formatter) -> fmt
 ///
 /// This function can be used to override the formatting of key or value types
 /// when printing with [`DotPrinter`].
+///
+/// # Errors
+///
+/// This function returns an error if the provided [`fmt::Formatter`] returns
+/// `Err`.
 pub fn bytes_display_fmt(value: &impl AsBytes, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "{:?}", value.as_bytes())
 }

--- a/src/raw/visitor/pretty_printer.rs
+++ b/src/raw/visitor/pretty_printer.rs
@@ -228,7 +228,7 @@ struct OverrideDisplay<'a, T> {
     fmt_fn: fn(&T, &mut fmt::Formatter<'_>) -> fmt::Result,
 }
 
-impl<'a, T> fmt::Display for OverrideDisplay<'a, T> {
+impl<T> fmt::Display for OverrideDisplay<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (self.fmt_fn)(self.value, f)
     }

--- a/src/raw/visitor/well_formed.rs
+++ b/src/raw/visitor/well_formed.rs
@@ -54,7 +54,7 @@ pub enum MalformedTreeError<K, V, const PREFIX_LEN: usize> {
     WrongChildrenCount {
         /// The key prefix identifying the inner node
         key_prefix: KeyPrefix,
-        /// The type of the inner node (InnerNode4, InnerNode16, etc)
+        /// The type of the inner node (`InnerNode4`, `InnerNode16`, etc)
         ///
         /// This field is guaranteed not to be [`NodeType::Leaf`]
         inner_node_type: NodeType,
@@ -324,7 +324,7 @@ impl<K: AsBytes, V, const PREFIX_LEN: usize> Error for MalformedTreeError<K, V, 
 /// In this context, well-formed means that in the tree:
 ///  1. there are no loops between nodes
 ///  2. every inner node has a number of children that is in range for the inner
-///     node type. For example, InnerNode16 has between 5 and 16 children.
+///     node type. For example, `InnerNode16` has between 5 and 16 children.
 ///  3. the elements of the key (as part of inner node prefixes and child
 ///     pointers) combine to match the leaf node key prefix
 ///  4. the `previous` and `next` pointers that form a doubly-linked list of
@@ -559,7 +559,7 @@ where
     fn default_output(&self) -> Self::Output {
         // Chose zero so that any places that call `default_output` don't influence the
         // overall count
-        Ok(Default::default())
+        Ok(WellFormedTreeStats::default())
     }
 
     fn combine_output(&self, o1: Self::Output, o2: Self::Output) -> Self::Output {

--- a/src/tagged_pointer.rs
+++ b/src/tagged_pointer.rs
@@ -180,7 +180,7 @@ impl<P, const MIN_BITS: u32> From<&mut P> for TaggedPointer<P, MIN_BITS> {
         //
         // Panics: Further, the pointer produced is guaranteed to be aligned for the
         // underlying type, meaning that we will not have any panics.
-        unsafe { Self::new_unchecked(reference as *mut _) }
+        unsafe { Self::new_unchecked(core::ptr::from_mut(reference)) }
     }
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -315,7 +315,7 @@ pub fn generate_key_with_prefix<const KEY_LENGTH: usize>(
     }
 
     let mut sorted_expansions = expansions.to_vec();
-    sorted_expansions.sort_by(|a, b| a.base_index.cmp(&b.base_index));
+    sorted_expansions.sort_by_key(|a| a.base_index);
 
     let full_key_len = expansions
         .iter()

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -359,7 +359,7 @@ where
     TreeMap::into_raw(tree).unwrap()
 }
 
-// disabled for miri because the runtime is too large, and this does not test
+// disabled for miri because the run-time is too large, and this does not test
 // any safety-critical stuff
 #[cfg(all(test, not(miri)))]
 mod tests {


### PR DESCRIPTION
Fixes #66. Commit description from last commit on branch:

# Description
The issue was that in the case that prefix search terminated in an inner
node due, it was confusing the cases of (1) running out of key bytes or
(2) an actual mismatch between bytes of the inner node prefix and the key
bytes. In case (1) we know that all the nodes of the subtree should be
returned by the iterator, since the key is a prefix of all those leaves.
In case (2), no nodes of the subtree should be returned, since there was
a mismatch all nodes will not be prefixed by the key.

The fix was to make the `InnerNodeSearchResultReason` have another
variant which reports when the search ran out of bytes.

# Testing
Regression tests were added in a previous commit and labeled
`should_panic`, this commit just removed that label and all tests still
passed.