### PR TITLE
Implement a fuzzing oracle for prefix iterator

### DIFF
--- a/fuzz/fuzz_targets/tree_map_api.rs
+++ b/fuzz/fuzz_targets/tree_map_api.rs
@@ -304,9 +304,13 @@ libfuzzer_sys::fuzz_target!(|actions: Vec<Action>| {
                 std::hint::black_box(v);
             },
             Action::Prefix(key) => {
-                // TODO: Provide an oracle implementation for prefix search (easy)
-                let v: Vec<_> = tree.prefix(&key).collect();
-                std::hint::black_box(v);
+                let tree_result: Vec<_> = tree.prefix(&key).collect();
+                let oracle_result: Vec<_> = oracle
+                    .range::<[u8], _>((Bound::Included(key.as_ref()), Bound::Unbounded))
+                    .take_while(|(k, _)| k.starts_with(&key))
+                    .collect();
+
+                assert_eq!(tree_result, oracle_result);
             },
             Action::Range(start, end) => {
                 if range_is_valid(&start, &end) {


### PR DESCRIPTION
**Description**
Implement a prefix iterator oracle by starting with a range iterator and
filtering the iter based on the item key being prefixed by the lookup
key.

**Motivation**
Previously the prefix fuzz action performed the lookup, but had no check
on the result. The only thing this fuzzer checked was that it didn't hit
any internal assertions or sanitizer errors. The oracle gives us
confidence that the prefix iterator is actually functioning as intended.

**Testing Done**
Ran the fuzzer for one hour with no findings.
