### PR TITLE
Optimize lookup for any descendant leaf

### DIFF
--- a/src/raw/representation.rs
+++ b/src/raw/representation.rs
@@ -8,7 +8,7 @@ use core::{
     ops::{Bound, RangeBounds, RangeInclusive},
 };
 
-use crate::{raw::minimum_unchecked, rust_nightly_apis::likely, AsBytes};
+use crate::{rust_nightly_apis::likely, AsBytes};
 
 mod header;
 pub use header::*;
@@ -472,16 +472,12 @@ pub unsafe trait InnerNodeCommon<K, V, const PREFIX_LEN: usize>:
         if likely!(len <= PREFIX_LEN) {
             (header.read_prefix(), None)
         } else {
-            // SAFETY: By construction a InnerNode, must have >= 1 children, this
-            // is even more strict since in the case of 1 child the node can be
-            // collapsed, so a InnerNode must have >= 2 children, so it's safe
-            // to search for the minium. And the same applies to the `minimum_unchecked`
-            // function
-            let (_, min_child) = self.min();
-            let leaf_ptr = unsafe { minimum_unchecked(min_child) };
+            // SAFETY: Given we have a shared reference to this leaf node, there must be no
+            // concurrent mutation on this node or any child node of this node.
+            let leaf_ptr = unsafe { any_subtree_leaf(self) };
 
-            // SAFETY: Since have a shared reference
-            // is safe to create a shared reference from it
+            // SAFETY: Since have a shared reference is safe to create a shared reference
+            // from it
             let leaf = unsafe { leaf_ptr.as_ref() };
             let leaf = leaf.key_ref().as_bytes();
 
@@ -519,6 +515,16 @@ pub unsafe trait InnerNodeCommon<K, V, const PREFIX_LEN: usize>:
     /// because if we had, no children this current node should have been
     /// deleted.
     fn max(&self) -> (u8, OpaqueNodePtr<K, V, PREFIX_LEN>);
+
+    /// Returns any child pointer from this node, preferring children that are
+    /// pointers to leaf nodes.
+    ///
+    /// This function is useful in context where we need to quickly find a leaf
+    /// of a subtree, but don't care how we get there.
+    fn any_child_prefer_leaf(&self) -> OpaqueNodePtr<K, V, PREFIX_LEN> {
+        // The minimum child is a valid choice
+        self.min().1
+    }
 }
 
 /// Common methods implemented by all inner nodes that will be used in the tree.
@@ -804,6 +810,33 @@ fn assert_valid_range_bounds(bound: &impl RangeBounds<u8>) {
             },
             _ => {},
         }
+    }
+}
+
+/// Find any leaf in the subtree rooted by `root`.
+///
+/// # Safety
+///  - This function cannot be called concurrently with any mutating operation
+///    on `root` or any child node of `root`. This function will arbitrarily
+///    read to any child in the given tree.
+#[inline]
+unsafe fn any_subtree_leaf<N, K, V, const PREFIX_LEN: usize>(
+    root: &N,
+) -> NodePtr<PREFIX_LEN, LeafNode<K, V, PREFIX_LEN>>
+where
+    N: InnerNodeCommon<K, V, PREFIX_LEN>,
+{
+    let mut current_node = root.any_child_prefer_leaf();
+
+    loop {
+        current_node = match_concrete_node_ptr!(match (current_node.to_node_ptr()) {
+            // SAFETY: No other concurrent mutation will happen, the reference returned from
+            // `as_ref` is also bounded to this loop, not returned outside.
+            InnerNode(inner_node) => unsafe { inner_node.as_ref().any_child_prefer_leaf() },
+            LeafNode(leaf_node) => {
+                return leaf_node;
+            },
+        });
     }
 }
 

--- a/src/raw/representation/inner_node_indirect.rs
+++ b/src/raw/representation/inner_node_indirect.rs
@@ -11,7 +11,7 @@ use self::index::NonMaxIndex;
 use crate::{
     raw::{
         representation::assert_valid_range_bounds, Header, InnerNode, InnerNode16, InnerNodeCommon,
-        InnerNodeDirect, InnerNodeSorted, Node, NodeType, OpaqueNodePtr,
+        InnerNodeDirect, InnerNodeSorted, LeafNode, Node, NodeType, OpaqueNodePtr,
     },
     rust_nightly_apis::maybe_uninit_slice_assume_init_ref,
 };
@@ -443,6 +443,22 @@ unsafe impl<K, V, const PREFIX_LEN: usize, const SIZE: usize> InnerNodeCommon<K,
             return (key as u8, child_pointers[usize::from(*idx)]);
         }
         unreachable!("inner node must have non-zero number of children");
+    }
+
+    fn any_child_prefer_leaf(&self) -> OpaqueNodePtr<K, V, PREFIX_LEN> {
+        let children = self.initialized_child_pointers();
+
+        // SAFETY: Since inner nodes must have at least two children, and the
+        // `InnerNodeIndirect` maintains a compact array of child pointers, this must be
+        // a valid access.
+        let first = unsafe { children.get_unchecked(0) };
+        if first.is::<LeafNode<K, V, PREFIX_LEN>>() {
+            return *first;
+        }
+
+        // SAFETY: Same as above, just for the second child
+        let second = unsafe { children.get_unchecked(1) };
+        *second
     }
 }
 

--- a/src/raw/representation/inner_node_sorted.rs
+++ b/src/raw/representation/inner_node_sorted.rs
@@ -14,7 +14,7 @@ use core::{
 use crate::{
     raw::{
         representation::assert_valid_range_bounds, Header, InnerNode, InnerNode48, InnerNodeCommon,
-        InnerNodeDirect, InnerNodeIndirect, Node, NodeType, OpaqueNodePtr,
+        InnerNodeDirect, InnerNodeIndirect, LeafNode, Node, NodeType, OpaqueNodePtr,
     },
     rust_nightly_apis::maybe_uninit_slice_assume_init_ref,
 };
@@ -545,6 +545,22 @@ unsafe impl<K, V, const PREFIX_LEN: usize, const SIZE: usize> InnerNodeCommon<K,
                 keys.last().copied().unwrap_unchecked(),
                 children.last().copied().unwrap_unchecked(),
             )
+        }
+    }
+
+    fn any_child_prefer_leaf(&self) -> OpaqueNodePtr<K, V, PREFIX_LEN> {
+        let (_, children) = self.initialized_portion();
+        // SAFETY: Any Node4 must have at least 2 children, so the `keys` and
+        // `children` arrays must be non-empty
+        unsafe {
+            let first = *children.get_unchecked(0);
+            if first.is::<LeafNode<K, V, PREFIX_LEN>>() {
+                return first;
+            }
+
+            // Must have at least two children right
+            let second = *children.get_unchecked(1);
+            second
         }
     }
 }


### PR DESCRIPTION
Instead of using `minimum_unchecked` to find an arbitrary descendant,
instead use a custom function that tries to quickly find any leaf of
a given subtree.

The default implementation for inner nodes is equivalent to the
`minimum_unchecked` function, but is override for the `InnerNodeSorted`
and `InnerNodeIndirect`. Both of these inner node types maintain
a compact array of child pointers, which makes it easy to select
a child node at random.

Rather than picking randomly, we're trying to find a leaf node as
quickly as possible. I'd previously read
<https://brooker.co.za/blog/2012/01/17/two-random.html>, which gave
me the idea to try a best-of-two strategy for looking for leaf node
child pointers. I couldn't say that this is the very best option,
only that it is easily proven correct (there are always two child
nodes in an inner node) and that testing later proved that it was
better than a single choice.

I wanted to do this optimization when I started reworking the range
iterator a little while ago. Specifically, the range operation needs
to do a "full prefix" search (as opposed to a pessimistic/optimistic
prefix-based search), which requires searching for a leaf node if a
given inner node has implicit bytes in the stored prefix. "Full
prefix" searches also happen in the insert code path.

Looking at the "full prefix" search code, it occured to me that using
the minimum as a way to find an arbitrary leaf node was a pretty good
option, but not the best. So I tried out the best-of-two stuff
realized that the overall improvement more most cases was marginal at
best. However, for one specific dataset and operation this was a huge
improvement:

```text
iai_callgrind::bench_insert_group::bench_from_iter skewed:...
  Baselines:                               |9b221e2
  Instructions:                   211822957|512411353            (-58.6615%) [-2.41905x]
  L1 Hits:                        283167619|616345853            (-54.0570%) [-2.17661x]
  LL Hits:                             5886|34218438             (-99.9828%) [-5813.53x]
  RAM Hits:                          551645|551715               (-0.01269%) [-1.00013x]
  Total read+write:               283725150|651116006            (-56.4248%) [-2.29488x]
  Estimated Cycles:               302504624|806748068            (-62.5032%) [-2.66689x]
```

`-60%`!!! It was consistent over multiple runs too. The reason for
this massive improvement is the structure of the `skewed` dataset.
`skewed` keys are an artificial dataset I use for testing, here is
some example data:

```text
[255]
[0, 255]
[0, 0, 255]
[0, 0, 0, 255]
[0, 0, 0, 0, 255]
[0, 0, 0, 0, 0, 255]
[0, 0, 0, 0, 0, 0, 255]
[0, 0, 0, 0, 0, 0, 0, 255]
[0, 0, 0, 0, 0, 0, 0, 0, 255]
[0, 0, 0, 0, 0, 0, 0, 0, 0, 255]
```

When inserted into the tree structure, this sequence of keys is a
worst case for lookup/insertion/deletion/etc because the number of
inner nodes is maximized. The insert operation is especially bad
because on each step of the lookup portion of the operation (finding
where to insert) we need to see if there is a "full prefix" mismatch.
The "full prefix" mismatch requires going to find a descendant leaf
node, which requires recursing down the whole long tree. However,
this optimization specifically prevents this because it checks two
children at each inner node and prefers the one that points to a
leaf node. That effectively makes the "full prefix" lookup constant
time (for this specific key dataset).

Overall, I don't think this optimization is hugely important, though
it was fun to investigate. I'll probably keep it because it helps the
skewed edge case performance a ton and doesn't hurt other datasets
much at all.

Passed all existing tests, no new tests.
